### PR TITLE
Bump Python version to 3.10.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ of different algorithms for a variety of data sources.
 ## Installation
 
 ### Dependencies
-The package requires Python 3 (>=3.9).
+The package requires Python 3 (>=3.10).
 
 ### Package Installation
 First clone the repository using `git`:

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -16,7 +16,7 @@ Installation
 Installation Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TCTrack is a Python package.
+TCTrack is a Python package (Python 3.10+).
 It can be installed by cloning the repository from GitHub and using pip::
 
     git clone https://github.com/Cambridge-ICCS/TCTrack

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,13 @@ authors = [
 ]
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Development Status :: 3 - Alpha",
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
In #26 I get failure for the tests when running 0n Python 3.9 only.

Since [Python 3.9 reaches end of life in October](https://devguide.python.org/versions/) I suggest we bump this now.