### PR TITLE
Te tidy docs

### DIFF
--- a/docs/api/tempest_extremes_api.rst
+++ b/docs/api/tempest_extremes_api.rst
@@ -8,7 +8,7 @@ It is written by Paul Ullrich and released under a BSD 2-clause license.
 For an overview of the functionalities, installation, and usage see the
 :doc:`Tempest Extremes section of the documentation <../tracking-algorithms/tempest_extremes>`.
 
-.. automodule:: tctrack.tempest_extremes
+.. py:module:: tctrack.tempest_extremes
 
 .. autoclass:: TETracker
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ extensions = [
     "sphinx.ext.napoleon",  # numpy docstring support
     "sphinx.ext.viewcode",  # links to highlighted source code
     "sphinx.ext.autodoc",  # pull in documentation from docstrings
-    "sphinx_toolbox.more_autodoc.typehints",  # use type hints from code/docstrings
+    "sphinx_autodoc_typehints",  # use type hints from code/docstrings
 ]
 
 templates_path = ["_templates"]

--- a/docs/tracking-algorithms/tempest_extremes.rst
+++ b/docs/tracking-algorithms/tempest_extremes.rst
@@ -19,6 +19,7 @@ For full details of the Tempest Extremes API in TCTrack see the
    :maxdepth: 2
    :hidden:
 
+.. py:module:: tctrack.tempest_extremes
 
 Installation
 ------------
@@ -56,16 +57,16 @@ tracks.
 
 Usage of Tempest Extremes in TCTrack is done through the ``tempest_extremes`` module.
 
-This provides the ``TETracker`` class that stores algorithm parameters and provides access
-to the methods.
-The detection and stitching algorithm can be configured through the various parameters
-in the ``DetectNodesParameters`` and ``StitchNodesParameters`` dataclasses.
+This provides the :class:`TETracker` class that stores algorithm parameters and provides
+access to the methods. The detection and stitching algorithm can be configured through
+the various parameters in the :class:`DetectNodesParameters` and
+:class:`StitchNodesParameters` dataclasses.
 
-In the following example we set up the DetectNodes functionality to run on a series of
-input files to generate output. We configure detection to be done based on minima in
-psl, with closed contours of psl and zgdiff, and merging of candidates within 6 degrees
-of one another. Additional output fields are also added for psl and orog so that they
-may be used with StitchNodes:
+In the following example we set up the :meth:`~TETracker.detect_nodes` functionality to
+run on a series of input files to generate output. We configure detection to be done
+based on minima in psl, with closed contours of psl and zgdiff, and merging of
+candidates within 6 degrees of one another. Additional output fields are also added for
+psl and orog so that they may be used with :meth:`~TETracker.stitch_nodes`:
 
 .. code-block:: python
 
@@ -105,8 +106,8 @@ This can then followed by StitchNodes which is set up to combine nodes into a tr
 are less than 8 degrees from one another, with a track length of at least 10 nodes and 8
 degrees end-to-end, with a maximum of 3 times missing between each pair of nodes. This
 is then filtered based upon the lattitude and surface altitude. The format of the
-``"tracks_out.txt"`` output file is described in
-:meth:`~tctrack.tempest_extremes.TETracker.stitch_nodes`:
+``"tracks_out.txt"`` output file is described in the documentation for
+:meth:`~TETracker.stitch_nodes`:
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ lint = [
 doc = [
     "sphinx<8.2.0",  # Pin version due to autodoc type hints incompatibilities
     "sphinx_rtd_theme",
-    "sphinx-toolbox",
     "blackdoc",
 ]
 dev = [

--- a/src/tctrack/tempest_extremes/tempest_extremes.py
+++ b/src/tctrack/tempest_extremes/tempest_extremes.py
@@ -285,7 +285,8 @@ class StitchNodesParameters:
     in_file: str | None = None
     """
     Filename of the DetectNodes output file. If this and ``in_list`` are ``None``, it
-    will be taken from the DetectNodes parameters. Called "in" in TempestExtremes.
+    will be taken from :attr:`DetectNodesParameters.output_file`. Called "in" in
+    TempestExtremes.
     """
 
     in_list: str | None = None
@@ -297,7 +298,8 @@ class StitchNodesParameters:
     in_fmt: str | None = None
     """
     Comma-separated list of the variables in the input file. If ``None``, it will be
-    taken from the DetectNodes parameters.
+    ``"lon,lat"`` and any others defined in
+    :attr:`DetectNodesParameters.output_commands`.
     """
 
     allow_repeated_times: bool = False
@@ -600,6 +602,23 @@ class TETracker:
         run according to the parameters in the :attr:`detect_nodes_parameters` attribute
         that were set when the :class:`TETracker` instance was created.
 
+        The output file is a plain text file containing each of the TC candidates at
+        each time from the input files. If :attr:`~DetectNodesParameters.out_header` is
+        ``True`` the first two lines will be a header describing the structure of the
+        data. After this each time is listed in the format:
+
+        .. code-block:: text
+
+           <year> <month> <day> <count> <hour>
+                  <i> <j> <lon> <lat> <var1> <var2> ...
+                  ...
+                  <i> <j> <lon> <lat> <var1> <var2> ...
+
+        - ``count`` is the number of nodes at that time.
+        - ``i``, ``j`` are the grid indices of the node.
+        - ``var1``, ``var2``, etc., are scalar variables as defined by
+          :attr:`~DetectNodesParameters.output_commands` (typically, psl, orog).
+
         Returns
         -------
         dict
@@ -689,15 +708,16 @@ class TETracker:
         .. code-block:: text
 
            start <N> <year> <month> <day> <hour>
-                 <i> <j> <lon> <lat> <var1> <var2> ... <year> <month> <day> <hour>
+                 <i> <j> <var1> <var2> ... <year> <month> <day> <hour>
                  ...
-                 <i> <j> <lon> <lat> <var1> <var2> ... <year> <month> <day> <hour>
+                 <i> <j> <var1> <var2> ... <year> <month> <day> <hour>
 
         - ``N`` is the number of nodes in the track (and number of lines below header).
         - ``i``, ``j`` are grid indices.
         - ``var1``, ``var2``, etc., are scalar variables as defined by
-          :attr:`~StitchNodesParameters.in_fmt` (typically, psl, orog).
-        - ``hour`` may instead be seconds if :attr:`~StitchNodesParameters.out_seconds` is ``True``.
+          :attr:`~StitchNodesParameters.in_fmt` (typically, lon, lat, psl, orog).
+        - ``hour`` may instead be seconds if :attr:`~StitchNodesParameters.out_seconds`
+          is ``True``.
 
         Returns
         -------

--- a/src/tctrack/tempest_extremes/tempest_extremes.py
+++ b/src/tctrack/tempest_extremes/tempest_extremes.py
@@ -203,7 +203,7 @@ class DetectNodesParameters:
         Defaults to ``None``.
     closed_contours : list[TEContour] | None
         Criteria for candidates to be eliminated if they do not have a closed contour.
-        Criteria are provided as a list of separate ``TEContour`` criteria.
+        Criteria are provided as a list of separate :class:`TEContour` criteria.
         Defaults to ``None``.
     merge_dist : float
         DetectNodes merges candidate points with a distance (in degrees
@@ -236,8 +236,8 @@ class DetectNodesParameters:
         Defaults to ``False``
     output_commands : list[TEOutputCommand] | None
         Criteria for any additional columns to be added to the output.
-        Criteria are provided as a list of separate ``TEOutputCommand`` criteria.
-        Defaults to ``None``.
+        Criteria are provided as a list of separate :class:`TEOutputCommand`
+        criteria.  Defaults to ``None``.
 
     See Also
     --------
@@ -274,7 +274,7 @@ class DetectNodesParameters:
     closed_contours: list[TEContour] | None = None
     """
     Criteria for candidates to be eliminated if they do not have a closed contour
-    as a list of separate ``TEContour`` criteria.
+    as a list of separate :class:`TEContour` criteria.
     Defaults to ``None``.
     """
 
@@ -316,9 +316,8 @@ class DetectNodesParameters:
 
     output_commands: list[TEOutputCommand] | None = None
     """
-    Criteria for any additional columns to be added to the output.
-    Criteria are provided as a list of separate ``TEOutputCommand`` criteria.
-    Defaults to ``None``.
+    Criteria for any additional columns to be added to the output. Criteria are provided
+    as a list of separate :class:`TEOutputCommand` criteria.  Defaults to ``None``.
     """
 
     def __str__(self) -> str:
@@ -338,8 +337,9 @@ class StitchNodesParameters:
     output_file : str | None
         The output filename to save the tracks. Called "out" in TempestExtremes.
     in_file : str | None, optional
-        Filename of the DetectNodes output file. If this and `in_list` are ``None``, it
-        will be taken from the DetectNodes parameters. Called "in" in TempestExtremes.
+        Filename of the DetectNodes output file. If this and ``in_list`` are ``None``,
+        it will be taken from the DetectNodes parameters. Called "in" in
+        TempestExtremes.
     in_list : str | None, optional
         File containing a list of input files to be processed together. This is
         unadvised to use at present as it is likely to be changed.
@@ -357,7 +357,7 @@ class StitchNodesParameters:
     time_end : str | None, optional
         Ending date / time for stitching tracks. Later times will be ignored.
     max_sep : float, default=5.0
-        The maximum distance allowed between candidates (degrees). "range" in
+        The maximum distance allowed between candidates (degrees). Called "range" in
         TempestExtremes.
     max_gap : int, default=0
         The number of missing points allowed between candidates.
@@ -395,8 +395,8 @@ class StitchNodesParameters:
 
     in_file: str | None = None
     """
-    Filename of the DetectNodes output file. If this and `in_list` are ``None``, it will
-    be taken from the DetectNodes parameters. Called "in" in TempestExtremes.
+    Filename of the DetectNodes output file. If this and ``in_list`` are ``None``, it
+    will be taken from the DetectNodes parameters. Called "in" in TempestExtremes.
     Defaults to ``None``.
     """
 
@@ -438,7 +438,7 @@ class StitchNodesParameters:
 
     max_sep: float = 5
     """
-    The maximum distance allowed between candidates (degrees). "range" in
+    The maximum distance allowed between candidates (degrees). Called "range" in
     TempestExtremes. Defaults to ``5.0``.
     """
 
@@ -719,11 +719,10 @@ class TETracker:
         """
         Call the DetectNodes utility of Tempest Extremes.
 
-        This will make a system call out to the DetectNodes method from
-        Tempest Extremes (provided it has been installed as an external dependency).
-        DetectNodes will be run according to the parameters in the
-        ``detect_nodes_parameters`` attribute that were set when the ``TETracker``
-        instance was created.
+        This will make a system call out to the DetectNodes method from Tempest Extremes
+        (provided it has been installed as an external dependency). DetectNodes will be
+        run according to the parameters in the :attr:`detect_nodes_parameters` attribute
+        that were set when the :class:`TETracker` instance was created.
 
         Returns
         -------

--- a/src/tctrack/tempest_extremes/tempest_extremes.py
+++ b/src/tctrack/tempest_extremes/tempest_extremes.py
@@ -155,7 +155,7 @@ class TEThreshold(TypedDict):
     To add a filter requiring latitude ``"lat"`` to be less than 40 degrees for
     10 or more points in each track:
 
-    >>> TEOutputCommand(var="lat", op="<=", value=40, count=10)
+    >>> TEThreshold(var="lat", op="<=", value=40, count=10)
     {"var": "lat", "op": "<=", "value": 40, "count": 10},
     """
 
@@ -182,63 +182,6 @@ class DetectNodesParameters:
     """
     Dataclass containing values used by the DetectNodes operation of TE.
 
-    Parameters
-    ----------
-    in_data : list[str] | None
-        List of strings of NetCDF input files.
-        Defaults to ``None``.
-    out_header : bool
-        Whether to include header at the top of the output file.
-        Defaults to ``False``.
-    output_file : str | None
-        Output nodefile to write to from the detection procedure.
-        Defaults to ``None``.
-    search_by_min : str | None
-        Input variable in NetCDF files for selecting candidate points (defined as local
-        minima).
-        Defaults to ``None`` in TCTrack (and then ``"PSL"`` in Tempest Extremes).
-    search_by_max : str | None
-        Input variable in NetCDF files for selecting candidate points (defined as local
-        maxima).
-        Defaults to ``None``.
-    closed_contours : list[TEContour] | None
-        Criteria for candidates to be eliminated if they do not have a closed contour.
-        Criteria are provided as a list of separate :class:`TEContour` criteria.
-        Defaults to ``None``.
-    merge_dist : float
-        DetectNodes merges candidate points with a distance (in degrees
-        great-circle-distance) shorter than the specified value. Among two candidates
-        within the merge distance, only the candidate with the lowest value of the
-        search_by_min field or highest value of the search_by_max field are retained.
-        Defaults to ``0.0``.
-    lat_name : str
-        string for the longitude dimension in the NetCDF files.
-        Defaults to ``"lat"``.
-    lat_name : str
-        string for the longitude dimension in the NetCDF files.
-        Defaults to ``"lat"``.
-    min_lat : float
-        Minimum latitude for candidate points.
-        Defaults to ``0.0``.
-    min_lat : float
-        Maximum latitude for candidate points.
-        Defaults to ``0.0``.
-        If max_lat and min_lat are equal then these arguments are ignored.
-    min_lon : float
-        Minimum longitude for candidate points.
-        Defaults to ``0.0``.
-    min_lon : float
-        Maximum longitude for candidate points.
-        Defaults to ``0.0``.
-        If max_lon and min_lon are equal then these arguments are ignored.
-    regional : bool
-        should lat-lon grid be periodic in the longitudinal direction.
-        Defaults to ``False``
-    output_commands : list[TEOutputCommand] | None
-        Criteria for any additional columns to be added to the output.
-        Criteria are provided as a list of separate :class:`TEOutputCommand`
-        criteria.  Defaults to ``None``.
-
     See Also
     --------
     TEContour : The class used to define contour criteria
@@ -251,31 +194,30 @@ class DetectNodesParameters:
     """
 
     in_data: list[str] | None = None
-    """List of strings of NetCDF input files. Defaults to ``None``."""
+    """List of strings of NetCDF input files."""
 
     out_header: bool = False
-    """Include header at the top of the output file? Defaults to ``False``."""
+    """Include header at the top of the output file?"""
 
     output_file: str | None = None
-    """Output nodefile to write to. Defaults to ``None``."""
+    """Output nodefile to write to."""
 
     search_by_min: str | None = None
     """
     Input variable in NetCDF files for selecting candidate points (defined as local
-    minima). Defaults to ``None`` in TCTrack (and then ``"PSL"`` in Tempest Extremes).
+    minima). If ``None``, then uses ``"PSL"`` in Tempest Extremes.
     """
 
     search_by_max: str | None = None
     """
     Input variable in NetCDF files for selecting candidate points (defined as local
-    maxima). Defaults to ``None``.
+    maxima).
     """
 
     closed_contours: list[TEContour] | None = None
     """
     Criteria for candidates to be eliminated if they do not have a closed contour
     as a list of separate :class:`TEContour` criteria.
-    Defaults to ``None``.
     """
 
     merge_dist: float = 0.0
@@ -284,40 +226,39 @@ class DetectNodesParameters:
     great-circle-distance) shorter than the specified value. Among two candidates
     within the merge distance, only the candidate with the lowest value of the
     search_by_min field or highest value of the search_by_max field are retained.
-    Defaults to ``0.0``.
     """
 
     lat_name: str = "lat"
-    """String for the latitude dimension in the NetCDF files, defaults to ``"lat"``."""
+    """String for the latitude dimension in the NetCDF files."""
 
     lon_name: str = "lon"
-    """String for the longitude dimension in the NetCDF files, defaults to ``"lat"``."""
+    """String for the longitude dimension in the NetCDF files."""
 
     min_lat: float = 0.0
-    """Minimum latitude for candidate points. Defaults to ``0.0``."""
+    """Minimum latitude for candidate points."""
 
     max_lat: float = 0.0
     """
-    Maximum latitude for candidate points. Defaults to ``0.0``.
+    Maximum latitude for candidate points.
     If max_lat and min_lat are equal then these arguments are ignored.
     """
 
     min_lon: float = 0.0
-    """Minimum longitude for candidate points. Defaults to ``0.0``."""
+    """Minimum longitude for candidate points."""
 
     max_lon: float = 0.0
     """
-    Maximum longitude for candidate points. Defaults to ``0.0``.
+    Maximum longitude for candidate points.
     If ``max_lon`` and ``min_lon`` are equal then these arguments are ignored.
     """
 
     regional: bool = False
-    """Should lat-lon grid be periodic in longitude. Defaults to ``False``."""
+    """Should lat-lon grid be periodic in longitude."""
 
     output_commands: list[TEOutputCommand] | None = None
     """
     Criteria for any additional columns to be added to the output. Criteria are provided
-    as a list of separate :class:`TEOutputCommand` criteria.  Defaults to ``None``.
+    as a list of separate :class:`TEOutputCommand` criteria.
     """
 
     def __str__(self) -> str:
@@ -332,58 +273,6 @@ class DetectNodesParameters:
 class StitchNodesParameters:
     """Dataclass containing values used by the StitchNodes operation of TE.
 
-    Parameters
-    ----------
-    output_file : str | None
-        The output filename to save the tracks. Called "out" in TempestExtremes.
-    in_file : str | None, optional
-        Filename of the DetectNodes output file. If this and ``in_list`` are ``None``,
-        it will be taken from the DetectNodes parameters. Called "in" in
-        TempestExtremes.
-    in_list : str | None, optional
-        File containing a list of input files to be processed together. This is
-        unadvised to use at present as it is likely to be changed.
-    in_fmt : str | None, optional
-        Comma-separated list of the variables in the input file. If ``None``, it will be
-        taken from the DetectNodes parameters.
-    allow_repeated_times : bool, default=False
-        If ``False``, an error is thrown if there are multiple sections in the input
-        nodefile with the same time.
-    caltype : str, default="standard"
-        Type of calendar to use. Options are: ``"standard"`` (365 days with
-        leap years), ``"noleap"``, ``"360_day"``.
-    time_begin : str | None, optional
-        Starting date / time for stitching tracks. Earlier times will be ignored.
-    time_end : str | None, optional
-        Ending date / time for stitching tracks. Later times will be ignored.
-    max_sep : float, default=5.0
-        The maximum distance allowed between candidates (degrees). Called "range" in
-        TempestExtremes.
-    max_gap : int, default=0
-        The number of missing points allowed between candidates.
-    min_time : int | str, default=1
-        The minimum required length of a path. Either as an integer for the number of
-        candidates, or a string for total duration, e.g. ``"24h"``.
-    min_endpoint_dist : float, default=0
-        The minimum required distance between the first and last candidates (degrees).
-    min_path_dist : float, default=0
-        The minimum required acumulated distance along the path (degrees).
-    threshold_filters: list[TEThreshold] | None, optional
-        Filters for paths based on the number of nodes that satisfy a threshold.
-        Called "thresholdcmd" in TempestExtremes.
-    prioritize : str | None, optional
-        The variable to use to determine the precedence (lowest to highest) of nodes for
-        matching to the next position.
-    add_velocity : bool, default=False
-        Whether to include the velocity components (m/s) of the movement of the TC to
-        the output file.
-    out_file_format : str, default="gfdl"
-        Format of the output file. ``"gfdl"``, ``"csv"``, or ``"csvnoheader"``.
-        See :meth:`TETracker.stitch_nodes` for details.
-    out_seconds : bool, default=False
-        For GFDL output file types, determines whether to report the sub-daily time in
-        seconds (``True``) or hours (``False``).
-
     References
     ----------
     `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#StitchNodes>`_
@@ -397,100 +286,87 @@ class StitchNodesParameters:
     """
     Filename of the DetectNodes output file. If this and ``in_list`` are ``None``, it
     will be taken from the DetectNodes parameters. Called "in" in TempestExtremes.
-    Defaults to ``None``.
     """
 
     in_list: str | None = None
     """
     File containing a list of input files to be processed together. This is unadvised to
-    use at present as it is likely to be changed. Defaults to ``None``.
+    use at present as it is likely to be changed.
     """
 
     in_fmt: str | None = None
     """
     Comma-separated list of the variables in the input file. If ``None``, it will be
-    taken from the DetectNodes parameters. Defaults to ``None``.
+    taken from the DetectNodes parameters.
     """
 
     allow_repeated_times: bool = False
     """
     If ``False``, an error is thrown if there are multiple sections in the input
-    nodefile with the same time. Defaults to ``False``.
+    nodefile with the same time.
     """
 
     caltype: str = "standard"
     """
-    Type of calendar to use. Options are: ``"standard"`` (365 days with leap
-    years), ``"noleap"``, ``"360_day"``. Defaults to ``"standard"``.
+    The type of calendar to use. Options are ``"standard"`` (365 days with leap years),
+    ``"noleap"``, ``"360_day"``.
     """
 
     time_begin: str | None = None
-    """
-    Starting date / time for stitching tracks. Earlier times will be ignored.
-    Defaults to ``None``.
-    """
+    """Starting date / time for stitching tracks. Earlier times will be ignored."""
 
     time_end: str | None = None
-    """
-    Ending date / time for stitching tracks. Later times will be ignored.
-    Defaults to ``None``.
-    """
+    """Ending date / time for stitching tracks. Later times will be ignored."""
 
     max_sep: float = 5
     """
     The maximum distance allowed between candidates (degrees). Called "range" in
-    TempestExtremes. Defaults to ``5.0``.
+    TempestExtremes.
     """
 
     max_gap: int = 0
-    """The number of missing points allowed between candidates. Defaults to ``0``."""
+    """The number of missing points allowed between candidates."""
 
     min_time: int | str = 1
     """
     The minimum required length of a path. Either as an integer for the number of
-    candidates, or a string for total duration, e.g. ``"24h"``. Defaults to ``1``.
+    candidates, or a string for total duration, e.g. ``"24h"``.
     """
 
     min_endpoint_dist: float = 0
-    """
-    The minimum required distance between the first and last candidates (degrees).
-    Defaults to ``0``.
-    """
+    """The minimum required distance between the first and last candidates (degrees)."""
 
     min_path_dist: float = 0
-    """
-    The minimum required acumulated distance along the path (degrees).
-    Defaults to ``0``.
-    """
+    """The minimum required acumulated distance along the path (degrees)."""
 
     threshold_filters: list[TEThreshold] | None = None
     """
-    Filters for paths based on the number of nodes that satisfy a threshold.
-    Called "thresholdcmd" in TempestExtremes. Defaults to ``None``.
+    Filters for paths based on the number of nodes that satisfy a threshold. Uses a list
+    of :class:`TEThreshold` objects.  Called "thresholdcmd" in TempestExtremes.
     """
 
     prioritize: str | None = None
     """
     The variable to use to determine the precedence (lowest to highest) of nodes for
-    matching to the next position. Defaults to ``None``.
+    matching to the next position.
     """
 
     add_velocity: bool = False
     """
-    Whether to include the velocity components (m/s) of the movement of the TC to
-    the output file. Defaults to ``False``.
+    Whether to include the velocity components (m/s) of the movement of the TC to the
+    output file.
     """
 
     out_file_format: str = "gfdl"
     """
     Format of the output file. ``"gfdl"``, ``"csv"``, or ``"csvnoheader"``.
-    Defaults to ``"gfdl"``. See :meth:`TETracker.stitch_nodes` for details.
+    See :meth:`TETracker.stitch_nodes` for details.
     """
 
     out_seconds: bool = False
     """
     For GFDL output file types, determines whether to report the sub-daily time in
-    seconds (``True``) or hours (``False``). Defaults to ``False``.
+    seconds (``True``) or hours (``False``).
     """
 
     def __str__(self) -> str:


### PR DESCRIPTION
I have modified the TempestExtremes documentation to make it a bit tidier. The main changes are:
- Removed duplicates of the Stitch/DetectNodesParameters attributes, keeping the individual attribute docstrings (similar to TEContour etc). Usually, I would want to include attributes in the class docstring but I think this is unnecessary for dataclasses.
- Changed autodoc typehints to use sphinx_autodoc_typehints since the format is tidier. I also removed the definitions of default values from the descriptions since these are much clearer with sphinx_autodoc_typehints.
- Added a description of the output file to the description of `detect_nodes`. Closes #25 