### PR TITLE
Small docs updates

### DIFF
--- a/docs/tracking-algorithms/tempest_extremes.rst
+++ b/docs/tracking-algorithms/tempest_extremes.rst
@@ -46,8 +46,15 @@ TCTrack has been built against (5feb3a0 - a more recent version may work if you 
 the latest features).
 It will then build using CMake
 Once this is complete the Tempest Extremes executeables can then be found in
-``tempestextremes/build_serial/bin/``.
+``tempestextremes/build/bin/``.
 
+To use these from TCTrack you will need to add the directory to your ``PATH`` so that
+the executeables can be found at runtime::
+
+    export PATH=$PATH:~/tempestextremes/build/bin
+
+Note: you will need to modify this as appropriate if you cloned Tempest Extremes
+somewhere other than ``~/``.
 
 Usage
 -----

--- a/docs/tracking-algorithms/tempest_extremes.rst
+++ b/docs/tracking-algorithms/tempest_extremes.rst
@@ -140,10 +140,12 @@ is then filtered based upon the lattitude and surface altitude. The format of th
 
     run_info = te_tracker.stitch_nodes()
 
-However, it is likely preferable to run both
-:meth:`~tctrack.tempest_extremes.TETracker.detect_nodes` and
-:meth:`~tctrack.tempest_extremes.TETracker.stitch_nodes` together. Which can be done
-with a single :class:`~tctrack.tempest_extremes.TETracker` object:
+
+The above examples demonstrate running :meth:`~TETracker.detect_nodes` and
+:meth:`~TETracker.stitch_nodes` separately.
+However, it is likely that users will want to run both in succession which can be done
+with a single :class:`~tctrack.tempest_extremes.TETracker` object defined using the
+appropriate :class:`DetectNodesParameters` and :class:`StitchNodesParameters`:
 
 .. code-block:: python
 


### PR DESCRIPTION
This is intended to address the comments in #30 

It clarifies installation and adding to `PATH` as well as the option to run detect nodes and stitch nodes from a single tracker object (which will likely change soon as part of #27)

It does not address the 'error' message raised by the stdout from Tempest Extremes as this is perhaps not a priority at present, but I have opened a separate issue to log this in #33