### PR TITLE
Convert StitchNodes outputs into CF-compliant NetCDF

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,8 @@
 
 import os
 import sys
+import platform
+import subprocess
 
 project = "TCTrack"
 copyright = "2025, Jack Atkinson, Sam Avis"
@@ -17,6 +19,11 @@ release = "0.1.0"
 # Set the root for the project to be analysed in sphinx
 sys.path.insert(0, os.path.abspath("../src"))
 
+# Add the path to udunits2 library installed via homebrew for macOS
+if platform.system() == 'Darwin':
+    brew_prefix = subprocess.check_output(['brew', '--prefix'], text=True).strip()
+    os.environ['DYLD_LIBRARY_PATH'] = f"{brew_prefix}/lib:" + os.environ.get('DYLD_LIBRARY_PATH', '')
+
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
@@ -25,6 +32,7 @@ extensions = [
     "sphinx.ext.viewcode",  # links to highlighted source code
     "sphinx.ext.autodoc",  # pull in documentation from docstrings
     "sphinx_autodoc_typehints",  # use type hints from code/docstrings
+    "sphinx.ext.autosectionlabel",  # Auto-generate reference labels for sections
 ]
 
 templates_path = ["_templates"]
@@ -39,3 +47,4 @@ html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 autodoc_member_order = "bysource"
 napoleon_preprocess_types = True
+autosectionlabel_prefix_document = True

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -16,6 +16,9 @@ Installation
 Installation Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Before using TCTrack ensure that any external :ref:`getting-started/index:dependencies` as required are
+installed as :ref:`described below <getting-started/index:dependencies>`.
+
 TCTrack is a Python package (Python 3.10+).
 It can be obtained by cloning the repository from GitHub::
 
@@ -42,6 +45,30 @@ The `dev` optional dependencies include the `test`, `lint`, and `doc` subgroups.
 
 Dependencies
 ------------
+
+UDUNITS
+~~~~~~~
+
+TCTrack makes use of the `cf-python <https://ncas-cms.github.io/cf-python/>`_ package to
+generate CF-compliant NetCDF files.
+This brings with it the dependency of `UDUNITS <https://docs.unidata.ucar.edu/udunits/current/>`_
+which needs to be installed by the user.
+
+Binaries are available on most systems, for example on Ubuntu::
+
+    apt-get install -y libudunits2-dev
+
+or on mac one can use homebrew::
+
+    brew install udunits
+
+noting that we may need to add the library to the dynamic path e.g.::
+
+    export DYLD_LIBRARY_PATH=/opt/homebrew/Cellar/udunits/2.2.28/lib
+
+
+Tracking algorithms
+~~~~~~~~~~~~~~~~~~~
 
 To use some tracking algorithms requires additional dependencies to be installed, namely
 the libraries that they are wrapping.

--- a/docs/tracking-algorithms/tempest_extremes.rst
+++ b/docs/tracking-algorithms/tempest_extremes.rst
@@ -142,22 +142,29 @@ is then filtered based upon the lattitude and surface altitude. The format of th
     run_info = te_tracker.stitch_nodes()
 
 
-The above examples demonstrate running :meth:`~TETracker.detect_nodes` and
-:meth:`~TETracker.stitch_nodes` separately.
-However, it is likely that users will want to run both in succession which can be done
-using the :meth:`~TETracker.run_tracker` method after defining a :class:`TETracker`
-object with appropriate :class:`DetectNodesParameters` and
-:class:`StitchNodesParameters`:
+Finally, after running stitch nodes to generate tracks, one can write the tracks to
+a NetCDF file fully compliant with the `CF-Conventions <https://cfconventions.org/>`_
+(specifically the `trajectory data format <https://cfconventions.org/Data/cf-conventions/cf-conventions-1.11/cf-conventions.html#trajectory-data>`_)
+using :meth:`~TETracker.to_netcdf`:
+
+.. code-block:: python
+
+    te_tracker.to_netcdf("my_cf_tracks.nc")
+
+This can be read using any NetCDF reading utility, though
+`cf-python <https://ncas-cms.github.io/cf-python/>`_ will load it following the
+`CF data model <https://ncas-cms.github.io/cf-python/#cf-data-model>`_.
+
+The above examples demonstrate running :meth:`~TETracker.detect_nodes`,
+:meth:`~TETracker.stitch_nodes`, and :meth:`~TETracker.to_netcdf` separately. However,
+it is likely that users will want to these in succession which can be done using the
+:meth:`~TETracker.run_tracker` method after defining a :class:`TETracker` object with
+appropriate :class:`DetectNodesParameters` and :class:`StitchNodesParameters`:
 
 .. code-block:: python
 
     te_tracker = te.TETracker(dn_params, sn_params)
-    te_tracker.run_tracker("tracks_out.nc")
-
-The resulting ``"tracks_out.nc"`` output file will contain the tracks data converted
-into a `CF trajectory
-<https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/aphs04.html>`_
-netCDF file.
+    te_tracker.run_tracker("my_cf_tracks.nc")
 
 When running in this way there are certain parameters that *should not* be
 set. In :class:`StitchNodesParameters`, :attr:`~StitchNodesParameters.in_fmt`

--- a/docs/tracking-algorithms/tempest_extremes.rst
+++ b/docs/tracking-algorithms/tempest_extremes.rst
@@ -21,6 +21,7 @@ For full details of the Tempest Extremes API in TCTrack see the
 
 .. Import the tempest_extremes module to use references throughout this page.
 .. py:module:: tctrack.tempest_extremes
+   :no-index:
 
 Installation
 ------------

--- a/src/tctrack/tempest_extremes/tempest_extremes.py
+++ b/src/tctrack/tempest_extremes/tempest_extremes.py
@@ -33,8 +33,8 @@ class Track:
     start_time : Datetime360Day | DatetimeNoLeap | DatetimeGregorian
         Start time of the track as a datetime or cftime object.
     data : dict
-        dict of data for various variables along the track.
-            timestamp nd other variables as supplied in file
+        Dict of data for various variables along the track.
+        Timestamp and other variables as supplied in file.
     """
 
     def __init__(

--- a/src/tctrack/tempest_extremes/tempest_extremes.py
+++ b/src/tctrack/tempest_extremes/tempest_extremes.py
@@ -198,7 +198,7 @@ class TEContour(TypedDict):
 
     References
     ----------
-    `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#DetectNodes>`_
+    `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#DetectNodes>`__
     and the `DetectNodes Source <https://github.com/ClimateGlobalChange/tempestextremes/blob/master/src/nodes/DetectNodes.cpp>`_
 
     Examples
@@ -247,7 +247,7 @@ class TEOutputCommand(TypedDict):
 
     References
     ----------
-    `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#DetectNodes>`_
+    `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#DetectNodes>`__
     and the `DetectNodes Source <https://github.com/ClimateGlobalChange/tempestextremes/blob/master/src/nodes/DetectNodes.cpp>`_
 
     Examples
@@ -289,7 +289,7 @@ class TEThreshold(TypedDict):
 
     References
     ----------
-    `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#StitchNodes>`_
+    `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#StitchNodes>`__
     and the `StitchNodes Source <https://github.com/ClimateGlobalChange/tempestextremes/blob/master/src/nodes/StitchNodes.cpp>`_
 
     Examples
@@ -331,7 +331,7 @@ class DetectNodesParameters:
 
     References
     ----------
-    `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#DetectNodes>`_
+    `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#DetectNodes>`__
     and the `DetectNodes Source <https://github.com/ClimateGlobalChange/tempestextremes/blob/master/src/nodes/DetectNodes.cpp>`_
     """
 
@@ -420,7 +420,7 @@ class StitchNodesParameters:
 
     References
     ----------
-    `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#StitchNodes>`_
+    `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#StitchNodes>`__
     and the `StitchNodes Source <https://github.com/ClimateGlobalChange/tempestextremes/blob/master/src/nodes/StitchNodes.cpp>`_
     """
 
@@ -813,7 +813,7 @@ class TETracker:
 
         References
         ----------
-        `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#DetectNodes>`_
+        `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#DetectNodes>`__
         and the `DetectNodes Source <https://github.com/ClimateGlobalChange/tempestextremes/blob/master/src/nodes/DetectNodes.cpp>`_
 
         Examples
@@ -915,7 +915,7 @@ class TETracker:
 
         References
         ----------
-        `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#StitchNodes>`_
+        `TempestExtremes Documentation <https://climate.ucdavis.edu/tempestextremes.php#StitchNodes>`__
         and the `StitchNodes Source <https://github.com/ClimateGlobalChange/tempestextremes/blob/master/src/nodes/StitchNodes.cpp>`_
 
         Examples
@@ -1208,8 +1208,8 @@ class TETracker:
 
         References
         ----------
-        `CF-Conventions v1.1 - H.4. Trajectory Data<https://cfconventions.org/Data/cf-conventions/cf-conventions-1.11/cf-conventions.html#trajectory-data>`_
-        `cf-python documentation<https://ncas-cms.github.io/cf-python/index.html>`_
+        `CF-Conventions v1.1 - H.4. Trajectory Data <https://cfconventions.org/Data/cf-conventions/cf-conventions-1.11/cf-conventions.html#trajectory-data>`_
+        `cf-python documentation <https://ncas-cms.github.io/cf-python/index.html>`_
 
         Examples
         --------

--- a/tests/unit/test_tempest_extremes.py
+++ b/tests/unit/test_tempest_extremes.py
@@ -789,43 +789,118 @@ class TestTETrackerStitchNodes:
         ):
             tracker.stitch_nodes()
 
+    def _mock_tracks_data(self):
+        """Generate expected track data for a given track index and variable names."""
+        return {
+            "varnames": ["i", "j", "lon", "lat", "psl", "orog"],
+            "datenames": ["year", "month", "day", "hour"],
+            "tracks": [
+                [
+                    {
+                        "date": ["1950", "1", "1", "3"],
+                        "line": [
+                            "164",
+                            "332",
+                            "57.832031",
+                            "-12.070312",
+                            "1.005377e+05",
+                            "0.000000e+00",
+                        ],
+                    },
+                    {
+                        "date": ["1950", "1", "1", "6"],
+                        "line": [
+                            "163",
+                            "332",
+                            "57.480469",
+                            "-12.070312",
+                            "1.005820e+05",
+                            "0.000000e+00",
+                        ],
+                    },
+                ],
+                [
+                    {
+                        "date": ["1950", "1", "2", "0"],
+                        "line": [
+                            "843",
+                            "275",
+                            "296.542969",
+                            "-25.429688",
+                            "9.970388e+04",
+                            "2.633214e+02",
+                        ],
+                    },
+                    {
+                        "date": ["1950", "1", "2", "6"],
+                        "line": [
+                            "850",
+                            "266",
+                            "299.003906",
+                            "-27.539062",
+                            "9.989988e+04",
+                            "6.951086e+01",
+                        ],
+                    },
+                ],
+            ],
+        }
+
     @pytest.fixture
     def mock_gfdl_file(self, tmp_path):
         """Fixture to create a mock GFDL file with two tracks."""
         file_path = tmp_path / "tracks_out_gfdl.txt"
-        file_path.write_text(
-            "start\t2\t1950\t1\t1\t3\n"
-            "\t164\t332\t57.832031\t-12.070312\t1.005377e+05\t0.000000e+00\t1950\t1\t1\t3\n"
-            "\t163\t332\t57.480469\t-12.070312\t1.005820e+05\t0.000000e+00\t1950\t1\t1\t6\n"
-            "start\t2\t1950\t1\t2\t0\n"
-            "\t843\t275\t296.542969\t-25.429688\t9.970388e+04\t2.633214e+02\t1950\t1\t2\t0\n"
-            "\t850\t266\t299.003906\t-27.539062\t9.989988e+04\t6.951086e+01\t1950\t1\t2\t6\n"
-        )
+        mock_data = self._mock_tracks_data()
+
+        content = ""
+        for track in mock_data["tracks"]:
+            # Add the start line for each track
+            content += "start\t{}\t{}\n".format(len(track), "\t".join(track[0]["date"]))
+            # Add the data lines for each observation in the track
+            content += "\n".join(
+                "\t{}\t{}".format("\t".join(obs["line"]), "\t".join(obs["date"]))
+                for obs in track
+            )
+            content += "\n"
+
+        file_path.write_text(content)
         return str(file_path)
 
     @pytest.fixture
     def mock_csv_file(self, tmp_path):
         """Fixture to create a mock CSV file with two tracks."""
         file_path = tmp_path / "tracks_out_csv.txt"
-        file_path.write_text(
-            "track_id,year,month,day,hour,i,j,lon,lat,psl,orog\n"
-            "0,1950,1,1,3,164,332,57.832031,-12.070312,1.005377e+05,0.000000e+00\n"
-            "0,1950,1,1,6,163,332,57.480469,-12.070312,1.005820e+05,0.000000e+00\n"
-            "1,1950,1,2,0,843,275,296.542969,-25.429688,9.970388e+04,2.633214e+02\n"
-            "1,1950,1,2,6,850,266,299.003906,-27.539062,9.989988e+04,6.951086e+01\n"
+        mock_data = self._mock_tracks_data()
+
+        content = (
+            ",".join(["track_id"] + mock_data["datenames"] + mock_data["varnames"])
+            + "\n"
         )
+        for i, track in enumerate(mock_data["tracks"]):
+            # Add the data lines for each observation in the track
+            content += "\n".join(
+                ",".join([str(i)] + obs["date"] + obs["line"]) for obs in track
+            )
+            content += "\n"
+
+        file_path.write_text(content)
         return str(file_path)
 
     @pytest.fixture
     def mock_csvnohead_file(self, tmp_path):
         """Fixture to create a mock CSV file without a header and with two tracks."""
         file_path = tmp_path / "tracks_out_csvnohead.txt"
-        file_path.write_text(
-            "0,1950,1,1,3,164,332,57.832031,-12.070312,1.005377e+05,0.000000e+00\n"
-            "0,1950,1,1,6,163,332,57.480469,-12.070312,1.005820e+05,0.000000e+00\n"
-            "1,1950,1,2,0,843,275,296.542969,-25.429688,9.970388e+04,2.633214e+02\n"
-            "1,1950,1,2,6,850,266,299.003906,-27.539062,9.989988e+04,6.951086e+01\n"
-        )
+        mock_data = self._mock_tracks_data()
+
+        content = ""
+        for i, track in enumerate(mock_data["tracks"]):
+            # Add the data lines for each observation in the track
+            content += "\n".join(
+                ",".join([str(i)] + obs["date"] + obs["line"]) for obs in track
+            )
+            content += "\n"
+
+        file_path.write_text(content)
         return str(file_path)
 
     @pytest.mark.parametrize(

--- a/tests/unit/test_tempest_extremes.py
+++ b/tests/unit/test_tempest_extremes.py
@@ -1061,7 +1061,8 @@ class TestTETrackerStitchNodes:
         """Test the to_netcdf method by writing out and validating with cf.read."""
         # Get the mock file and set up the TETracker
         mock_file = request.getfixturevalue(mock_file_fixture)
-        tracker = TETracker()
+        sn_params = StitchNodesParameters(in_fmt=["lon", "lat", "v1", "v2"])
+        tracker = TETracker(stitch_nodes_parameters=sn_params)
         tracker.stitch_nodes_parameters.output_file = mock_file
         tracker.stitch_nodes_parameters.out_file_format = file_format
 

--- a/tests/unit/test_tempest_extremes.py
+++ b/tests/unit/test_tempest_extremes.py
@@ -751,8 +751,10 @@ class TestTETrackerStitchNodes:
     ) -> None:
         """Check the values are being assigned properly from DetectNodesParameters."""
         tracker = TETracker(dn_params, sn_params)
-        assert tracker.stitch_nodes_parameters.in_file == expected[0]
-        assert tracker.stitch_nodes_parameters.in_fmt == expected[1]
+        expected_in_file, expected_in_fmt = expected
+        if expected_in_file is not None:
+            assert tracker.stitch_nodes_parameters.in_file == expected_in_file
+        assert tracker.stitch_nodes_parameters.in_fmt == expected_in_fmt
 
     def test_stitch_nodes_file_not_found(self, mocker) -> None:
         """Check stitch_nodes raises FileNotFoundError when executable is missing."""


### PR DESCRIPTION
Closes #36 

- [x] Add methods to read StitchNodes outputs into a generic representation
    - [x] Code
    - [x] Tests
    - [x] API Docs
    - [x] User Docs
- [x] Add method to write generic representation to CF-compliant NetCDF
- [x] Use StitchNodes parameters to provide metadata where it is missing from csvnohead - see #51 
- [x] Add user documentation
    - [x] Add [details on installing udunits](https://ncas-cms.github.io/cfunits/installation.html) to docs, and netcdf??
- [x] Add tests