### PR TITLE
Fix out_file_format + validation

### DIFF
--- a/src/tctrack/tempest_extremes/tempest_extremes.py
+++ b/src/tctrack/tempest_extremes/tempest_extremes.py
@@ -361,7 +361,7 @@ class StitchNodesParameters:
 
     out_file_format: str = "gfdl"
     """
-    Format of the output file. ``"gfdl"``, ``"csv"``, or ``"csvnoheader"``.
+    Format of the output file. ``"gfdl"``, ``"csv"``, or ``"csvnohead"``.
     See :meth:`TETracker.stitch_nodes` for details.
     """
 
@@ -370,6 +370,15 @@ class StitchNodesParameters:
     For GFDL output file types, determines whether to report the sub-daily time in
     seconds (``True``) or hours (``False``).
     """
+
+    def __post_init__(self):
+        """Validate parameters."""
+        if self.out_file_format not in ("gfdl", "csv", "csvnohead"):
+            msg = (
+                f"Invalid out_file_format ({self.out_file_format}). "
+                "Allowed values are 'gfdl', 'csv', or 'csvnohead'"
+            )
+            raise ValueError(msg)
 
     def __str__(self) -> str:
         """Improve the representation to users."""

--- a/src/tctrack/tempest_extremes/tempest_extremes.py
+++ b/src/tctrack/tempest_extremes/tempest_extremes.py
@@ -379,6 +379,12 @@ class StitchNodesParameters:
                 "Allowed values are 'gfdl', 'csv', or 'csvnohead'"
             )
             raise ValueError(msg)
+        if self.caltype not in ("standard", "noleap", "360_day"):
+            msg = (
+                f"Invalid caltype ({self.caltype}). "
+                "Allowed values are 'standard', 'noleap', or '360_day'"
+            )
+            raise ValueError(msg)
 
     def __str__(self) -> str:
         """Improve the representation to users."""

--- a/tests/unit/test_tempest_extremes.py
+++ b/tests/unit/test_tempest_extremes.py
@@ -81,15 +81,23 @@ class TestTETypes:
         StitchNodesParameters(**parameter)
 
     @pytest.mark.parametrize(
-        "parameter",
+        "parameter,msg",
         [
-            {"out_file_format": "invalid"},
-            {"caltype": "invalid"},
+            (
+                {"out_file_format": "invalid"},
+                r"Invalid out_file_format \(invalid\). "
+                + "Allowed values are 'gfdl', 'csv', or 'csvnohead'",
+            ),
+            (
+                {"caltype": "invalid"},
+                r"Invalid caltype \(invalid\). "
+                + "Allowed values are 'standard', 'noleap', or '360_day'",
+            ),
         ],
     )
-    def test_stitch_nodes_parameters_invalid(self, parameter) -> None:
+    def test_stitch_nodes_parameters_invalid(self, parameter, msg) -> None:
         """Check invalid StitchNodesParameters inputs correctly raise errors."""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=msg):
             StitchNodesParameters(**parameter)
 
     def test_te_contour(self) -> None:

--- a/tests/unit/test_tempest_extremes.py
+++ b/tests/unit/test_tempest_extremes.py
@@ -65,6 +65,29 @@ class TestTETypes:
         assert params.out_file_format == "gfdl"
         assert params.out_seconds is False
 
+    @pytest.mark.parametrize(
+        "parameter",
+        [
+            {"out_file_format": "gfdl"},
+            {"out_file_format": "csv"},
+            {"out_file_format": "csvnohead"},
+        ],
+    )
+    def test_stitch_nodes_parameters_valid(self, parameter) -> None:
+        """Check valid StitchNodesParameters inputs do not raise errors."""
+        StitchNodesParameters(**parameter)
+
+    @pytest.mark.parametrize(
+        "parameter",
+        [
+            {"out_file_format": "invalid"},
+        ],
+    )
+    def test_stitch_nodes_parameters_invalid(self, parameter) -> None:
+        """Check invalid StitchNodesParameters inputs correctly raise errors."""
+        with pytest.raises(ValueError):
+            StitchNodesParameters(**parameter)
+
     def test_te_contour(self) -> None:
         """Test that TEContour creates the appropriate typed dict."""
         contour = TEContour(var="psl", delta=200.0, dist=5.5, minmaxdist=0.0)

--- a/tests/unit/test_tempest_extremes.py
+++ b/tests/unit/test_tempest_extremes.py
@@ -71,6 +71,9 @@ class TestTETypes:
             {"out_file_format": "gfdl"},
             {"out_file_format": "csv"},
             {"out_file_format": "csvnohead"},
+            {"caltype": "standard"},
+            {"caltype": "noleap"},
+            {"caltype": "360_day"},
         ],
     )
     def test_stitch_nodes_parameters_valid(self, parameter) -> None:
@@ -81,6 +84,7 @@ class TestTETypes:
         "parameter",
         [
             {"out_file_format": "invalid"},
+            {"caltype": "invalid"},
         ],
     )
     def test_stitch_nodes_parameters_invalid(self, parameter) -> None:


### PR DESCRIPTION
Fixes the description for `out_file_format` to use `"csvnohead"` rather than `"csvnoheader"` (closes #38).
Also adds validation checks for `out_file_format` and `caltype`.