### PR TITLE
Tracks variable names from in_fmt

### DIFF
--- a/src/tctrack/tempest_extremes/tempest_extremes.py
+++ b/src/tctrack/tempest_extremes/tempest_extremes.py
@@ -969,7 +969,7 @@ class TETracker:
         current_track_id = 0  # Initialize track ID
 
         # Get variable names from in_fmt
-        var_names = self.stitch_nodes_parameters.in_fmt or []
+        var_names = self.stitch_nodes_parameters.in_fmt
 
         with open(file_path, "r") as file:
             for line in file:

--- a/src/tctrack/tempest_extremes/tempest_extremes.py
+++ b/src/tctrack/tempest_extremes/tempest_extremes.py
@@ -1056,7 +1056,7 @@ class TETracker:
                     variables_dict = {"grid_i": int(row[5]), "grid_j": int(row[6])}
                     variables_dict.update(
                         {
-                            var_name: float(row[7+i])
+                            var_name: float(row[7 + i])
                             for i, var_name in enumerate(var_names)
                         }
                     )

--- a/src/tctrack/tempest_extremes/tempest_extremes.py
+++ b/src/tctrack/tempest_extremes/tempest_extremes.py
@@ -1016,9 +1016,6 @@ class TETracker:
         """
         tracks = {}
 
-        # Get variable names from in_fmt
-        var_names = self.stitch_nodes_parameters.in_fmt or []
-
         with open(file_path, "r") as file:
             reader = (
                 csv.DictReader(file, skipinitialspace=True)
@@ -1054,6 +1051,10 @@ class TETracker:
                     track_id = int(row[0])
                     year, month, day, hour = map(int, row[1:5])
                     variables_dict = {"grid_i": int(row[5]), "grid_j": int(row[6])}
+                    # Get variable names from in_fmt
+                    var_names = self.stitch_nodes_parameters.in_fmt or [
+                        f"var_{i + 1}" for i in range(len(row[7:]))
+                    ]
                     variables_dict.update(
                         {
                             var_name: float(row[7 + i])

--- a/tests/unit/test_tempest_extremes.py
+++ b/tests/unit/test_tempest_extremes.py
@@ -577,32 +577,43 @@ class TestTETrackerStitchNodes:
         assert result["stderr"] == "Mocked stderr output"
         assert result["returncode"] == 0
 
-    def test_stitch_nodes_values_from_detect_nodes(self) -> None:
+    @pytest.mark.parametrize(
+        "dn_params, sn_params, expected",
+        [
+            pytest.param(None, None, [None, None], id="Check defaults"),
+            pytest.param(
+                DetectNodesParameters(
+                    output_file="file.txt",
+                    output_commands=[
+                        TEOutputCommand(var="v1", operator="min", dist=0.0),
+                        TEOutputCommand(var="v2", operator="max", dist=3.0),
+                    ],
+                ),
+                None,
+                ["file.txt", ["lon", "lat", "v1", "v2"]],
+                id="Check the auto-assignment works",
+            ),
+            pytest.param(
+                DetectNodesParameters(
+                    output_file="file.txt",
+                    output_commands=[
+                        TEOutputCommand(var="v1", operator="min", dist=0.0),
+                        TEOutputCommand(var="v2", operator="max", dist=3.0),
+                    ],
+                ),
+                StitchNodesParameters(in_file="file2.txt", in_fmt=["a", "b"]),
+                ["file2.txt", ["a", "b"]],
+                id="Check defined values aren't overriden",
+            ),
+        ],
+    )
+    def test_stitch_nodes_values_from_detect_nodes(
+        self, dn_params, sn_params, expected
+    ) -> None:
         """Check the values are being assigned properly from DetectNodesParameters."""
-        # Define the DetectNodes parameters to test against
-        output_commands = [
-            TEOutputCommand(var="v1", operator="min", dist=0.0),
-            TEOutputCommand(var="v2", operator="max", dist=3.0),
-        ]
-        dn_params = DetectNodesParameters(
-            output_file="file.txt", output_commands=output_commands
-        )
-
-        # Check defaults
-        tracker = TETracker()
-        assert tracker.stitch_nodes_parameters.in_file is None
-        assert tracker.stitch_nodes_parameters.in_fmt is None
-
-        # Check the auto-assignment works
-        tracker = TETracker(dn_params)
-        assert tracker.stitch_nodes_parameters.in_file == "file.txt"
-        assert tracker.stitch_nodes_parameters.in_fmt == ["lon", "lat", "v1", "v2"]
-
-        # Ensure defined values don't get overriden
-        sn_params = StitchNodesParameters(in_file="file2.txt", in_fmt=["a", "b"])
         tracker = TETracker(dn_params, sn_params)
-        assert tracker.stitch_nodes_parameters.in_file == "file2.txt"
-        assert tracker.stitch_nodes_parameters.in_fmt == ["a", "b"]
+        assert tracker.stitch_nodes_parameters.in_file == expected[0]
+        assert tracker.stitch_nodes_parameters.in_fmt == expected[1]
 
     def test_stitch_nodes_file_not_found(self, mocker) -> None:
         """Check stitch_nodes raises FileNotFoundError when executable is missing."""

--- a/tests/unit/test_tempest_extremes.py
+++ b/tests/unit/test_tempest_extremes.py
@@ -578,13 +578,15 @@ class TestTETrackerStitchNodes:
         assert result["returncode"] == 0
 
     def test_stitch_nodes_values_from_dn(self) -> None:
-        """Check the values are being assigned properly from DetectNodesParameters"""
+        """Check the values are being assigned properly from DetectNodesParameters."""
         # Define the DetectNodes parameters to test against
         output_commands = [
             TEOutputCommand(var="v1", operator="min", dist=0.0),
             TEOutputCommand(var="v2", operator="max", dist=3.0),
         ]
-        dn_params = DetectNodesParameters(output_file="file.txt", output_commands=output_commands)
+        dn_params = DetectNodesParameters(
+            output_file="file.txt", output_commands=output_commands
+        )
 
         # Check defaults
         tracker = TETracker()
@@ -689,10 +691,10 @@ class TestTETrackerStitchNodes:
                         "data": {
                             "grid_i": [164, 163],
                             "grid_j": [332, 332],
-                            "lon": [57.832031, 57.480469],
-                            "lat": [-12.070312, -12.070312],
-                            "psl": [1.005377e05, 1.005820e05],
-                            "orog": [0.0, 0.0],
+                            "var_1": [57.832031, 57.480469],
+                            "var_2": [-12.070312, -12.070312],
+                            "var_3": [1.005377e05, 1.005820e05],
+                            "var_4": [0.0, 0.0],
                         },
                     },
                     {
@@ -701,10 +703,10 @@ class TestTETrackerStitchNodes:
                         "data": {
                             "grid_i": [843, 850],
                             "grid_j": [275, 266],
-                            "lon": [296.542969, 299.003906],
-                            "lat": [-25.429688, -27.539062],
-                            "psl": [9.970388e04, 9.989988e04],
-                            "orog": [2.633214e02, 6.951086e01],
+                            "var_1": [296.542969, 299.003906],
+                            "var_2": [-25.429688, -27.539062],
+                            "var_3": [9.970388e04, 9.989988e04],
+                            "var_4": [2.633214e02, 6.951086e01],
                         },
                     },
                 ],
@@ -749,10 +751,10 @@ class TestTETrackerStitchNodes:
                         "data": {
                             "grid_i": [164, 163],
                             "grid_j": [332, 332],
-                            "lon": [57.832031, 57.480469],
-                            "lat": [-12.070312, -12.070312],
-                            "psl": [1.005377e05, 1.005820e05],
-                            "orog": [0.0, 0.0],
+                            "var_1": [57.832031, 57.480469],
+                            "var_2": [-12.070312, -12.070312],
+                            "var_3": [1.005377e05, 1.005820e05],
+                            "var_4": [0.0, 0.0],
                         },
                     },
                     {
@@ -761,10 +763,10 @@ class TestTETrackerStitchNodes:
                         "data": {
                             "grid_i": [843, 850],
                             "grid_j": [275, 266],
-                            "lon": [296.542969, 299.003906],
-                            "lat": [-25.429688, -27.539062],
-                            "psl": [9.970388e04, 9.989988e04],
-                            "orog": [2.633214e02, 6.951086e01],
+                            "var_1": [296.542969, 299.003906],
+                            "var_2": [-25.429688, -27.539062],
+                            "var_3": [9.970388e04, 9.989988e04],
+                            "var_4": [2.633214e02, 6.951086e01],
                         },
                     },
                 ],
@@ -777,7 +779,6 @@ class TestTETrackerStitchNodes:
         tracker = TETracker()
         tracker.stitch_nodes_parameters.output_file = mock_file
         tracker.stitch_nodes_parameters.out_file_format = file_format
-        tracker.stitch_nodes_parameters.in_fmt = ["lon", "lat", "psl", "orog"]
         tracks = tracker.tracks()
 
         # Assertions

--- a/tests/unit/test_tempest_extremes.py
+++ b/tests/unit/test_tempest_extremes.py
@@ -752,6 +752,7 @@ class TestTETrackerStitchNodes:
         tracker = TETracker()
         tracker.stitch_nodes_parameters.output_file = mock_file
         tracker.stitch_nodes_parameters.out_file_format = file_format
+        tracker.stitch_nodes_parameters.in_fmt = ["var_1", "var_2", "var_3", "var_4"]
         tracks = tracker.tracks()
 
         # Assertions

--- a/tests/unit/test_tempest_extremes.py
+++ b/tests/unit/test_tempest_extremes.py
@@ -577,6 +577,31 @@ class TestTETrackerStitchNodes:
         assert result["stderr"] == "Mocked stderr output"
         assert result["returncode"] == 0
 
+    def test_stitch_nodes_values_from_dn(self) -> None:
+        """Check the values are being assigned properly from DetectNodesParameters"""
+        # Define the DetectNodes parameters to test against
+        output_commands = [
+            TEOutputCommand(var="v1", operator="min", dist=0.0),
+            TEOutputCommand(var="v2", operator="max", dist=3.0),
+        ]
+        dn_params = DetectNodesParameters(output_file="file.txt", output_commands=output_commands)
+
+        # Check defaults
+        tracker = TETracker()
+        assert tracker.stitch_nodes_parameters.in_file is None
+        assert tracker.stitch_nodes_parameters.in_fmt is None
+
+        # Check the auto-assignment works
+        tracker = TETracker(dn_params)
+        assert tracker.stitch_nodes_parameters.in_file == "file.txt"
+        assert tracker.stitch_nodes_parameters.in_fmt == ["lon", "lat", "v1", "v2"]
+
+        # Ensure defined values don't get overriden
+        sn_params = StitchNodesParameters(in_file="file2.txt", in_fmt=["a", "b"])
+        tracker = TETracker(dn_params, sn_params)
+        assert tracker.stitch_nodes_parameters.in_file == "file2.txt"
+        assert tracker.stitch_nodes_parameters.in_fmt == ["a", "b"]
+
     def test_stitch_nodes_file_not_found(self, mocker) -> None:
         """Check stitch_nodes raises FileNotFoundError when executable is missing."""
         # Mock subprocess.run to simulate a FileNotFoundError
@@ -664,10 +689,10 @@ class TestTETrackerStitchNodes:
                         "data": {
                             "grid_i": [164, 163],
                             "grid_j": [332, 332],
-                            "var_1": [57.832031, 57.480469],
-                            "var_2": [-12.070312, -12.070312],
-                            "var_3": [1.005377e05, 1.005820e05],
-                            "var_4": [0.0, 0.0],
+                            "lon": [57.832031, 57.480469],
+                            "lat": [-12.070312, -12.070312],
+                            "psl": [1.005377e05, 1.005820e05],
+                            "orog": [0.0, 0.0],
                         },
                     },
                     {
@@ -676,10 +701,10 @@ class TestTETrackerStitchNodes:
                         "data": {
                             "grid_i": [843, 850],
                             "grid_j": [275, 266],
-                            "var_1": [296.542969, 299.003906],
-                            "var_2": [-25.429688, -27.539062],
-                            "var_3": [9.970388e04, 9.989988e04],
-                            "var_4": [2.633214e02, 6.951086e01],
+                            "lon": [296.542969, 299.003906],
+                            "lat": [-25.429688, -27.539062],
+                            "psl": [9.970388e04, 9.989988e04],
+                            "orog": [2.633214e02, 6.951086e01],
                         },
                     },
                 ],
@@ -724,10 +749,10 @@ class TestTETrackerStitchNodes:
                         "data": {
                             "grid_i": [164, 163],
                             "grid_j": [332, 332],
-                            "var_1": [57.832031, 57.480469],
-                            "var_2": [-12.070312, -12.070312],
-                            "var_3": [1.005377e05, 1.005820e05],
-                            "var_4": [0.0, 0.0],
+                            "lon": [57.832031, 57.480469],
+                            "lat": [-12.070312, -12.070312],
+                            "psl": [1.005377e05, 1.005820e05],
+                            "orog": [0.0, 0.0],
                         },
                     },
                     {
@@ -736,10 +761,10 @@ class TestTETrackerStitchNodes:
                         "data": {
                             "grid_i": [843, 850],
                             "grid_j": [275, 266],
-                            "var_1": [296.542969, 299.003906],
-                            "var_2": [-25.429688, -27.539062],
-                            "var_3": [9.970388e04, 9.989988e04],
-                            "var_4": [2.633214e02, 6.951086e01],
+                            "lon": [296.542969, 299.003906],
+                            "lat": [-25.429688, -27.539062],
+                            "psl": [9.970388e04, 9.989988e04],
+                            "orog": [2.633214e02, 6.951086e01],
                         },
                     },
                 ],
@@ -752,7 +777,7 @@ class TestTETrackerStitchNodes:
         tracker = TETracker()
         tracker.stitch_nodes_parameters.output_file = mock_file
         tracker.stitch_nodes_parameters.out_file_format = file_format
-        tracker.stitch_nodes_parameters.in_fmt = ["var_1", "var_2", "var_3", "var_4"]
+        tracker.stitch_nodes_parameters.in_fmt = ["lon", "lat", "psl", "orog"]
         tracks = tracker.tracks()
 
         # Assertions
@@ -762,3 +787,31 @@ class TestTETrackerStitchNodes:
             assert track.observations == expected["observations"]
             for key, values in expected["data"].items():
                 assert track.data[key] == values
+
+    @pytest.mark.parametrize(
+        "file_format, mock_file_fixture",
+        [
+            ("gfdl", "mock_gfdl_file"),
+            ("csvnohead", "mock_csvnohead_file"),
+        ],
+    )
+    def test_tracks_header_names(self, file_format, mock_file_fixture, request) -> None:
+        """Test the track header names are assigned correctly by tracks()."""
+        # Use DetectNodesParameters to set the variable names
+        output_commands = [
+            TEOutputCommand(var="v1", operator="min", dist=0.0),
+            TEOutputCommand(var="v2", operator="min", dist=0.0),
+        ]
+        dn_params = DetectNodesParameters(output_commands=output_commands)
+        tracker = TETracker(dn_params)
+
+        # Read in the tracks
+        mock_file = request.getfixturevalue(mock_file_fixture)
+        tracker.stitch_nodes_parameters.output_file = mock_file
+        tracker.stitch_nodes_parameters.out_file_format = file_format
+        tracks = tracker.tracks()
+
+        # Check the track header names are correct
+        cols = ["timestamp", "grid_i", "grid_j", "lon", "lat", "v1", "v2"]
+        for track in tracks:
+            assert [*track.data.keys()] == cols

--- a/tests/unit/test_tempest_extremes.py
+++ b/tests/unit/test_tempest_extremes.py
@@ -577,7 +577,7 @@ class TestTETrackerStitchNodes:
         assert result["stderr"] == "Mocked stderr output"
         assert result["returncode"] == 0
 
-    def test_stitch_nodes_values_from_dn(self) -> None:
+    def test_stitch_nodes_values_from_detect_nodes(self) -> None:
         """Check the values are being assigned properly from DetectNodesParameters."""
         # Define the DetectNodes parameters to test against
         output_commands = [


### PR DESCRIPTION
TETracker.tracks will now use `in_fmt` (which in turn uses detect nodes' `output_commands` if left blank) for the variable names when reading in gfdl / csvnohead output files. Closes #40.
I have also made `in_fmt` a list rather than requiring a comma-separated-value string.

This doesn't currently use any other parameters because that would be done during the CF file writing.