### PR TITLE
Add pre-install item to readthedocs.yaml to install udunits

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,8 @@ python:
 # Set the OS, Python version and other tools you might need
 build:
   os: ubuntu-22.04
+  apt_packages:
+    - libudunits2-dev
   tools:
     python: "3.13"
 


### PR DESCRIPTION
In the [latest version of the docs](https://tctrack.readthedocs.io/en/latest/api/tempest_extremes_api.html#) there is no API documentation for Tempest Extremes.

Building main on my local machine showed no issues.

Digging into the [build logs](https://app.readthedocs.org/projects/tctrack/builds/29477742/) it seems it failed silently 😱  as there is no udunits on the rtd machine.
We need to get this on there before we try and build.

It seems one can provide apt packages [according to the docs](https://docs.readthedocs.com/platform/stable/config-file/v2.html#build-apt-packages).