### PR TITLE
Pin black version due to incompatibility with latest black.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
 ]
 lint = [
     "ruff",
+    "black<=25.1.0",  # Pin version due to blackdoc incompatibility. Remove once resolved
     "blackdoc",
     "mypy",
     "pytest",
@@ -50,6 +51,7 @@ doc = [
     "sphinx<8.2.0",  # Pin version due to autodoc type hints incompatibilities
     "sphinx_rtd_theme",
     "sphinx_autodoc_typehints",
+    "black<=25.1.0",  # Pin version due to blackdoc incompatibility. Remove once resolved
     "blackdoc",
 ]
 dev = [


### PR DESCRIPTION
The code quality workflow failed on the latest merg to main.
This is due to an incompatibility between blackdoc and the latest version of black.
See https://github.com/keewis/blackdoc/issues/248.

To fix I pin black at <= the previous release that worked.

I have explicitly run the code-quality workflow for this branch here: https://github.com/Cambridge-ICCS/TCTrack/actions/runs/17910306502