### PR TITLE
Pin python to 3.13 in codequality workflow

### DIFF
--- a/.github/workflows/codequality.yaml
+++ b/.github/workflows/codequality.yaml
@@ -37,7 +37,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.13' # Pinned to 3.13 due to failing build of h5py with python 3.14
   
     - name: Install Package and Dependencies
       run: |


### PR DESCRIPTION
h5py is currently not working with python 3.14 so I am pinning to python 3.13 in the codequality workflow for now. When resolved we can remove this and also add python 3.14 to the testing workflow.