### PR TITLE
Add Trajectory Parameters for TSTORMS

### DIFF
--- a/src/tctrack/tstorms/__init__.py
+++ b/src/tctrack/tstorms/__init__.py
@@ -2,8 +2,10 @@
 
 from .tstorms import (
     DriverParameters,
+    TrajectoryParameters,
 )
 
 __all__ = [
     "DriverParameters",
+    "TrajectoryParameters",
 ]

--- a/tests/unit/tstorms/test_tstorms.py
+++ b/tests/unit/tstorms/test_tstorms.py
@@ -7,9 +7,7 @@ pytest-mock to mock the results of subprocess calls to the system.
 
 import pytest
 
-from tctrack.tstorms import (
-    DriverParameters,
-)
+from tctrack.tstorms import DriverParameters, TrajectoryParameters
 
 
 @pytest.fixture
@@ -57,3 +55,34 @@ class TestTSTORMSTypes:
             UserWarning, match="`do_thickness` is set, but will have no effect.*"
         ):
             DriverParameters(**tstorms_filenames, do_thickness=True)
+
+    def test_trajectory_parameters_defaults(self) -> None:
+        """Check the default values for TrajectoryParameters."""
+        params = TrajectoryParameters()
+        # Check values of all defaults
+        assert params.r_crit == 900.0
+        assert params.wind_crit == 17.0
+        assert params.vort_crit == 3.5e-5
+        assert params.tm_crit == 0.5
+        assert params.thick_crit == 50.0
+        assert params.n_day_crit == 2
+        assert params.do_filter is True
+        assert params.lat_bound_n == 40.0
+        assert params.lat_bound_s == -40.0
+        assert params.do_spline is False
+        assert params.do_thickness is False
+
+    def test_trajectory_parameters_lat_bounds_error(self) -> None:
+        """Check ValueError when northern lat bound is less than southern lat bound."""
+        with pytest.raises(
+            ValueError,
+            match=r"Northern latitude bound.*is less than.*Southern latitude bound",
+        ):
+            TrajectoryParameters(lat_bound_n=-10.0, lat_bound_s=10.0)
+
+    def test_trajectory_parameters_do_thickness_warning(self) -> None:
+        """Check UserWarning when do_thickness is set to True."""
+        with pytest.warns(
+            UserWarning, match="`do_thickness` is set, but will have no effect.*"
+        ):
+            TrajectoryParameters(do_thickness=True)


### PR DESCRIPTION
As per the description, feeding into TSTORMS.

Adds trajectory parameters, defaults, and tests.

Note: I have changed some names from the Fortran to be more descriptive, or match duplication from driver parameters.

Currently I assume users set both parameter sets correctly, but perhaps we need to add a check for the repeated values in the tracker to ensure they are consistent, or raise a warning if not. I can see why you may want to set a different threshold, however.