### PR TITLE
docs: Add pages for TSTORMS to API and tracking algorithm.

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -7,3 +7,4 @@ API Documentation
 
    Core Utilities <core_api>
    Tempest Extremes <tempest_extremes_api>
+   TSTORMS <tstorms_api>

--- a/docs/api/tstorms_api.rst
+++ b/docs/api/tstorms_api.rst
@@ -1,0 +1,29 @@
+TSTORMS
+=======
+
+TSTORMS is an early tracking software for tropical cyclones originally developed
+by NOAA GFDL.
+It is made available under a GPL-2.0 license.
+
+For an overview of the functionalities, installation, and usage see the
+:doc:`TSTORMS section of the documentation <../tracking-algorithms/tstorms>`.
+
+.. py:module:: tctrack.tstorms
+
+.. .. autoclass:: TSTORMSTracker
+..    :members:
+..    :undoc-members:
+..    :show-inheritance:
+..    :inherited-members:
+
+.. autoclass:: DriverParameters
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :inherited-members:
+
+.. autoclass:: TrajectoryParameters
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :inherited-members:

--- a/docs/tracking-algorithms/index.rst
+++ b/docs/tracking-algorithms/index.rst
@@ -14,3 +14,4 @@ For full details of the API for each of the components please see the
    :caption: Tracking Algorithms
 
    Tempest Extremes <tempest_extremes>
+   TSTORMS <tstorms>

--- a/docs/tracking-algorithms/tstorms.rst
+++ b/docs/tracking-algorithms/tstorms.rst
@@ -1,0 +1,46 @@
+TSTORMS
+=======
+
+TSTORMS is an early tracking software for tropical cyclones originally developed
+by NOAA GFDL.
+It is made available under a GPL-2.0 license.
+
+TCTrack provides bindings for both the ``Driver`` routine for detecting candidate
+storms, also the ``Trajectories`` functionality for generating trajectories.
+
+For full details of the TSTORMS API in TCTrack see the
+:doc:`TCTrack TSTORMS API documentation <../api/tstorms_api>`.
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+.. Import the tempest_extremes module to use references throughout this page.
+.. py:module:: tctrack.tstorms
+   :no-index:
+
+Installation
+------------
+
+TODO
+
+Usage
+-----
+
+Cyclone tracking in TSTORMS consists of two phases: the "driver" which performs
+node detection of candidate storms for each snapshot in time, and "trajectories" which
+stitches together suitable nodes across timesteps to generate trajectories.
+
+Usage of TSTORMS in TCTrack is through the ``tstorms`` module.
+
+This provides the :class:`TSTORMSTracker` class that stores algorithm parameters and provides
+access to the methods. The driver and trajectory algorithms can be configured through
+the various parameters in the :class:`DriverParameters` and
+:class:`TrajectoryParameters` dataclasses.
+
+.. TODO
+.. Example of driver
+.. Example of trajectories
+.. Example of run_tracker
+.. Notes about duplicated parameters or other quirks
+.. Simple description of the algorithm


### PR DESCRIPTION
This adds basic plumbing for the TSTORMS docs.
The idea is that this can be merged so that docs can be added alongside the code in future PRs