### PR TITLE
Fix time decoding when opening output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dependencies = [
     "h5py<3.15.0",
-    "cf-python",
+    "cf-python>=3.0.0",
     "cftime",
 ]
 

--- a/src/tctrack/core/tracker.py
+++ b/src/tctrack/core/tracker.py
@@ -254,7 +254,7 @@ class TCTracker(ABC):
 
         # Create auxiliary coordinates for time, latitude, longitude
         # Convert time from cftime to num format to write out via cf
-        time_fill = -1e10
+        time_fill = -1e8
         time_data = cf.Data(
             [
                 date2num(
@@ -277,6 +277,7 @@ class TCTracker(ABC):
                 "units": cf.Units(
                     "days since 1970-01-01", calendar=trajectories[0].calendar
                 ),
+                "missing_value": time_fill,
             },
         )
 
@@ -294,6 +295,7 @@ class TCTracker(ABC):
                 "standard_name": "lat",
                 "long_name": "latitude",
                 "units": "degrees_north",
+                "missing_value": lat_lon_fill,
             },
         )
 
@@ -310,6 +312,7 @@ class TCTracker(ABC):
                 "standard_name": "lon",
                 "long_name": "longitude",
                 "units": "degrees_east",
+                "missing_value": lat_lon_fill,
             },
         )
 
@@ -355,6 +358,7 @@ class TCTracker(ABC):
 
             # Add the variable coordinate to the field
             field.set_data(variable_data, axes=(axis_traj, axis_obs))
+            field.set_property("missing_value", field_fill)
 
             # Add the global metadata
             if self.global_metadata:

--- a/tests/unit/core/test_tracker.py
+++ b/tests/unit/core/test_tracker.py
@@ -252,7 +252,8 @@ class TestTCTracker:
         # Check the fields (variables) - just one in this test
         variable = "test_var"
         # Properties
-        expected_field_properties = example_metadata()[variable].properties
+        expected_field_properties: dict = example_metadata()[variable].properties
+        expected_field_properties["missing_value"] = -1e10
         for key, value in expected_field_properties.items():
             assert field.get_property(key) == value, (
                 f"Metadata mismatch for field data: {variable} - {key}"
@@ -267,16 +268,19 @@ class TestTCTracker:
                 "standard_name": "lat",
                 "long_name": "latitude",
                 "units": "degrees_north",
+                "missing_value": -999.9,
             },
             "lon": {
                 "standard_name": "lon",
                 "long_name": "longitude",
                 "units": "degrees_east",
+                "missing_value": -999.9,
             },
             "time": {
                 "standard_name": "time",
                 "long_name": "time",
                 "units": "days since 1970-01-01",
+                "missing_value": -1e8,
             },
         }
         for variable, metadata in expected_construct_metadata.items():


### PR DESCRIPTION
This fixes the error in #99 where a ValueError is thrown when calling `xr.open_dataset`. The issue is due to a combination of two things:
- cftime converts times to integer microseconds during decoding.
- The fill value is set to -1e10 but this isn't recorded in the metadata.
When converted to microseconds this is too large for a 64-bit integer.

I have fixed this by adding `"missing_value"` properties to the output, and reducing the value to -1e8 for good measure. A cf-python minimum version is imposed due to [`set_property()`](https://ncas-cms.github.io/cf-python/method/cf.Field.set_property.html#cf.Field.set_property). This is done in the second commit (c3fdcea).

The first commit (bb53ec7) just splits the test for `to_netcdf` into multiple tests and simplifies the metadata test. This is needed to test for the `"missing_value"` properties.

Closes #99.