### PR TITLE
Update pyproject.toml

### DIFF
--- a/.github/workflows/codequality.yaml
+++ b/.github/workflows/codequality.yaml
@@ -37,7 +37,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13' # Pinned to 3.13 due to failing build of h5py with python 3.14
+        python-version: '3.x'
   
     - name: Install Package and Dependencies
       run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -30,11 +30,11 @@ jobs:
       matrix:
         # Supported Python versions on Linux Ubuntu
         os: ["ubuntu-latest"]
-        python-version: ["3.13", "3.12", "3.11", "3.10"]
+        python-version: ["3.14", "3.13", "3.12", "3.11", "3.10"]
         # test latest python version on macOS
         include:
         - os: macos-latest
-          python-version: "3.13"
+          python-version: "3.14"
 
     steps:
     - name: Install system dependencies (Ubuntu)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Typing :: Typed',
     "Operating System :: Unix",
     "Topic :: Scientific/Engineering",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 requires = ["setuptools>=80", "setuptools-scm[simple]>=8"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+
 [project]
 name = "tctrack"
 dynamic = ["version"]
@@ -12,10 +14,10 @@ authors = [
   { name="Sam Avis", email="sa2329@cam.ac.uk" },
 ]
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "GPL-3.0-or-later"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Development Status :: 3 - Alpha",
     "Natural Language :: English",
     "Programming Language :: Python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
 ]
 dependencies = [
-    "h5py<3.15.0",
+    "h5py>=3.16.0",
     "cf-python>=3.19.0; python_version > '3.10'",
     "cf-python<3.19.0; python_version <= '3.10'",
     "cftime",


### PR DESCRIPTION
Updates pyproject.toml to resolve some build warnings. Also adds python 3.14 because the issue with h5py (#90) no longer seems relevant. It installs without issue with python 3.14 and the tests pass.

Closes #148