### PR TITLE
Prepare for publishing on PyPI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,5 @@
 # Workflow to publish versioned commits to PyPI
+name: release
 
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,57 @@
+# Workflow to publish versioned commits to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+
+  build:
+    name: Build release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # REQUIRED for setuptools_scm
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install build tool
+        run: python -m pip install --upgrade build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tctrack
+
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="docs/images/TCTrack_Logo.svg" alt="TCTrack Logo">
+  <img src="https://raw.githubusercontent.com/Cambridge-ICCS/TCTrack/main/docs/images/TCTrack_Logo.svg" alt="TCTrack Logo">
 </div>
 
 # TCTrack
@@ -101,7 +101,7 @@ This work was funded by a philantropic donation to the
 [INIGO Insurance](https://inigoinsurance.com/) as part of the InSPIRe project.
 
 <p align="left">
-  <img src="docs/images/inigo_inspire.png" width="355">
+  <img src="https://raw.githubusercontent.com/Cambridge-ICCS/TCTrack/main/docs/images/inigo_inspire.png" width="355">
 </p>
 
 The TCTrack logo was designed by [Jack Atkinson](https://jackatkinson.net/) - [@jatkinson1000](https://github.com/jatkinson1000).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The package requires Python 3 (>=3.10).
 
 ### Package Installation
 We recommend using a Conda virtual environment for TCTrack in order to simplify the
-installation of dependencies.
+installation of dependencies (cf-python, esmpy/ESMF, UDUNITS).
 ```sh
 conda create -n tctrack-env -c conda-forge cf-python cf-plot udunits2 esmpy
 conda activate tctrack-env
@@ -38,9 +38,10 @@ TCTrack can then be installed using `pip`:
 pip install tctrack
 ```
 
-Futher details about installation, including how to install the individual tracking
-algorithms, are available in the
+See the
 [documentation](https://tctrack.readthedocs.io/en/latest/getting-started/index.html#installation).
+for futher details about installation and dependencies, including how to install the
+individual tracking algorithms.
 
 
 ## Using TCTrack

--- a/README.md
+++ b/README.md
@@ -25,22 +25,22 @@ the output of different algorithms for a variety of data sources.
 The package requires Python 3 (>=3.10).
 
 ### Package Installation
-First clone the repository using `git`:
+We recommend using a Conda virtual environment for TCTrack in order to simplify the
+installation of dependencies.
 ```sh
-git clone https://github.com/Cambridge-ICCS/TCTrack
+conda create -n tctrack-env -c conda-forge cf-python cf-plot udunits2 esmpy
+conda activate tctrack-env
+```
+When finished using TCTrack this can be turned off with `conda deactivate`.
+
+TCTrack can then be installed using `pip`:
+```sh
+pip install tctrack
 ```
 
-Set up and activate a virtual environment:
-```sh
-python3 -m venv .venv
-source .venv/bin/activate
-```
-When finished using TCTrack this can be turned off with `deactivate`.
-
-Then install the package using `pip`:
-```sh
-pip install --editable .
-```
+Futher details about installation, including how to install the individual tracking
+algorithms, are available in the
+[documentation](https://tctrack.readthedocs.io/en/latest/getting-started/index.html#installation).
 
 
 ## Using TCTrack
@@ -52,7 +52,7 @@ New users may wish to follow the [TCTrack tutorial](https://tctrack.readthedocs.
 using the scripts in the [`tutorial/`](https://github.com/Cambridge-ICCS/TCTrack/tree/main/tutorial)
 directory.
 
-For a complete description of the library API see 
+For a complete description of the library API see
 [API documentation](https://tctrack.readthedocs.io/en/latest/api/index.html).
 
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ cyclones in an accessible manner to generate high-quality and
 It can be used for tracking cyclones in simulations and observations, and to compare
 the output of different algorithms for a variety of data sources.
 
-> [!WARNING]  
-> The software is currently in pre-release and may therefore be subject to changes.
-
 
 ## Installation
 

--- a/docs/data/preprocessing_data.rst
+++ b/docs/data/preprocessing_data.rst
@@ -9,22 +9,6 @@ cf-python since it provides a uniform interface and it is a dependency of TCTrac
 For full documentation of the routines described on these pages and more see the
 `cf python documentation <https://ncas-cms.github.io/cf-python/>`_.
 
-.. _preprocessing_deps:
-
-Dependencies
-------------
-
-Any regridding with cf-python requires `esmpy <https://earthsystemmodeling.org/esmpy/>`_
-and `ESMF <https://earthsystemmodeling.org/>`_ as dependencies. These are not
-pip-installable but can be installed in a conda environment:
-
-.. code-block:: bash
-
-    conda create -n tctrack_env
-    conda activate tctrack_env
-    conda install -c conda-forge esmpy h5py
-    pip install tctrack
-
 .. _combine_time:
 
 Combining in Time
@@ -187,8 +171,7 @@ Regridding
 ----------
 
 .. note::
-    To regrid using cf-python requires esmpy and ESMF to be installed as dependencies
-    (:ref:`see above <preprocessing_deps>`). There are also other tools available
+    To regrid using cf-python requires :ref:`esmpy and ESMF to be installed as dependencies <getting-started/index:esmpy>`. There are also other tools available
     including xarray, `NCO <https://nco.sourceforge.net/nco.html>`_ (ncremap), and `CDO
     <https://code.mpimet.mpg.de/projects/cdo/wiki/tutorial>`_ (cdo remap...).
 

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -3,10 +3,10 @@ Getting Started
 
 This getting started guide is intended for new users of TCTrack to get them up
 and running as quickly as possible whilst introducing the main concepts.
-More advanced users should consult the full :doc:`api documentation`<../api/index>`.
+More advanced users should consult the full :doc:`api documentation <../api/index>`.
 
 After reading the installation information here new users may wish to work through the
-:doc:`tutorial `<tutorial>` to see examples of how TCTrack is used and familiarise
+:doc:`tutorial <tutorial>` to see examples of how TCTrack is used and familiarise
 themselves with the workflow before using their own data.
 
 .. toctree::
@@ -17,23 +17,50 @@ themselves with the workflow before using their own data.
 Installation
 ------------
 
-Installation Instructions
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Environment
+~~~~~~~~~~~
 
-Before using TCTrack ensure that any external :ref:`getting-started/index:dependencies` as required are
-installed as :ref:`described below <getting-started/index:dependencies>`.
+TCTrack is a Python package and requires Python version 3.10 or later.
 
-TCTrack is a Python package (Python 3.10+).
-It can be obtained by cloning the repository from GitHub::
+Before installing TCTrack ensure that any external :ref:`dependencies
+<getting-started/index:dependencies>` are installed. This can be done manually as
+:ref:`described below <getting-started/index:dependencies>`. However, the recommended
+approach is to install these non-python dependencies using a conda virtual environment.
+
+To install conda we recommend using `miniforge
+<https://github.com/conda-forge/miniforge>`_. Once miniforge is installed conda can be
+initialised with the below command. This can also be added to your shell rc file. ::
+
+    source /path/to/miniforge3/etc/profile.d/conda.sh
+
+Then create and activate the conda virtual environment with the relevant dependencies
+installed::
+
+    conda create -n tctrack-env -c conda-forge cf-python cf-plot udunits2 esmpy
+    conda activate tctrack-env
+
+When finished using TCTrack this environment can be turned off with ``conda deactivate``.
+
+The individual tracking algorithms will also need to be :ref:`installed separately
+<getting-started/index:tracking algorithms>`.
+
+
+Installation from PyPI
+~~~~~~~~~~~~~~~~~~~~~~
+
+Once the environment has been set up TCTrack can be installed. It is easiest to do this
+from PyPI using pip::
+
+     pip install tctrack
+
+
+Installation from source
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Alternatively, it can be installed from source by cloning the repository from GitHub::
 
     git clone https://github.com/Cambridge-ICCS/TCTrack
     cd TCTrack
-
-Installation is performed using pip, run from within the cloned source directory.
-It is recommended that this is done from within a virtual environment::
-
-    python3 -m venv .venv
-    source .venv/bin/activate
 
 pip can then be run to install the code from the source into the environment::
 
@@ -69,6 +96,20 @@ or on mac one can use homebrew::
 noting that we may need to add the library to the dynamic path e.g.::
 
     export DYLD_LIBRARY_PATH=/opt/homebrew/Cellar/udunits/2.2.28/lib
+
+
+esmpy
+~~~~~
+
+Any regridding of data with cf-python requires `esmpy
+<https://earthsystemmodeling.org/esmpy/>`_ and `ESMF
+<https://earthsystemmodeling.org/>`_ as dependencies. This is not needed directly in the
+TCTrack package but may be needed for initial pre-processing of data, such as in the
+tutorial and described in the :doc:`../data/preprocessing_data` page.
+
+These are not pip-installable but can be installed in a conda environment::
+
+    conda install -c conda-forge esmpy
 
 
 Tracking algorithms

--- a/docs/getting-started/tutorial.rst
+++ b/docs/getting-started/tutorial.rst
@@ -23,6 +23,9 @@ you may choose to follow just one.
 Installation
 ------------
 
+.. warning::
+   The tutorial currently only works for python 3.11 and above.
+
 First, follow the :ref:`installation instructions <getting-started/index:installation>`.
 Make sure to use a conda environment and install TCTrack from source (not from PyPI) so
 that the tutorial scripts are downloaded.

--- a/docs/getting-started/tutorial.rst
+++ b/docs/getting-started/tutorial.rst
@@ -23,34 +23,20 @@ you may choose to follow just one.
 Installation
 ------------
 
-For more information see the :ref:`installation instructions <getting-started/index:installation>`.
-
-In this tutorial, cf-python and esmf are required as dependencies for preprocessing
-data, as described in the :doc:`../data/preprocessing_data` page. The reccomended way of
-installing these and other non-python dependencies is via conda, for which we reccomend
-`miniforge <https://github.com/conda-forge/miniforge>`_. From a conda base environment,
-create a new environment with the dependencies installed::
-
-    conda create -n tctrack-env -c conda-forge cf-python cf-plot udunits2 esmpy
-    conda activate tctrack-env
-
-Then, install TCTrack from GitHub::
-
-    git clone git@github.com:Cambridge-ICCS/TCTrack.git
-    cd TCTrack
-    pip install .
+First, follow the :ref:`installation instructions <getting-started/index:installation>`.
+Make sure to use a conda environment and install TCTrack from source (not from PyPI) so
+that the tutorial scripts are downloaded.
 
 The next step is to install the trackers we want to call from TCTrack, in this case
 :doc:`Tempest Extremes <../tracking-algorithms/tempest_extremes>` and
 :doc:`TSTORMS <../tracking-algorithms/tstorms>`.
 
-Ensure that the following dependencies have also been installed
+To do this, first ensure that the following dependencies have also been installed:
 
 * NetCDF (with C++ bindings and Tempest Extremes and Fortran bindings for TSTORMS)
 * A C++ Compiler (for Tempest Extremes)
 * A Fortran Compiler (for TSTORMS) -- ifort is assumed,
   though :ref:`others are available <tracking-algorithms/tstorms:installation>`
-
 
 From your cloned version of TCTrack navigate to the ``tutorial/`` directory at the top
 level::

--- a/docs/tracking-algorithms/track.rst
+++ b/docs/tracking-algorithms/track.rst
@@ -1,6 +1,12 @@
 TRACK
 =====
 
+.. attention::
+   The output tracks from TRACK are not currently correct. This is due to TCTrack using
+   incorrect input parameters. See `this issue
+   <https://github.com/Cambridge-ICCS/TCTrack/issues/81>`_ for details or if you are able
+   to contribute to help fix the issue.
+
 TRACK is a software package and algorithm for tracking and analysing tropical
 cyclones and other weather systems in meteorological and oceanic datasets. It
 is developed by Kevin Hodges at the University of Reading, UK, and released

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = "GPL-3.0-or-later"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -1,9 +1,8 @@
 # TCTrack Tutorial
 
-This directory contains a number of scripts used in the
-[TCTrack tutorial](https://github.com/Cambridge-ICCS/TCTrack/tree/main/docs).
-
-For full details please see the [online tutorial documentation](https://github.com/Cambridge-ICCS/TCTrack/tree/main/docs).
+This directory contains a number of scripts used in the TCTrack tutorial. For full
+details please see the [online tutorial
+documentation](https://tctrack.readthedocs.io/en/latest/getting-started/tutorial.html).
 
 Contained in this directory are:
 


### PR DESCRIPTION
This prepares the repo for publishing on PyPI. Closes #147

- Adds a workflow to publish the repo to PyPI when a version tag (eg v0.2) is pushed using [pypi-publish](https://github.com/marketplace/actions/pypi-publish). I have tested this on TestPyPI ([see here](https://test.pypi.org/project/tctrack/)).
- Fixes README images on PyPI by using a github link rather than a relative file link.
- Fix the tutorial README link to go to the docs. Closes #157 
- Remove the pre-release warning on the README and update the pyproject.toml development status to beta.
- Updated installation instructions to use a conda environment and remove duplicate installation instructions in the tutorial / preprocessing data page.
- Add esmpy/ESMF to the dependencies in the documentation.
- Add a disclaimer that TRACK doesn't give correct output.

The workflow will not work for the initial upload to PyPI, so once this is merged I will upload it to PyPI as v0.2 (since v0.1 was initially used) and set up trusted publishing so the workflow can be used in future.