### PR TITLE
Fix the standard name of longitude / latitude

### DIFF
--- a/docs/data/output_file.rst
+++ b/docs/data/output_file.rst
@@ -93,12 +93,12 @@ These coordinate variables are always present in a dataset:
   - Auxiliary coordinate.
   - *Attributes* include ``units`` and ``calendar`` amongst others
 
-- **lat**: Latitude of the observation.
+- **latitude**: Latitude of the observation.
   
   - *Dimensions*: ``(trajectory, observation)``
   - Auxiliary coordinate.
 
-- **lon**: Longitude of the observation.
+- **longitude**: Longitude of the observation.
   
   - *Dimensions*: ``(trajectory, observation)``
   - Auxiliary coordinate.
@@ -181,7 +181,7 @@ Perhaps the quickest way of inspecting the metadata is to use the
                     time:units = "days since 1950-01-01 12:00:00.000000" ;
                     time:missing_value = -100000000. ;
                     time:calendar = "360_day" ;
-            double lat(trajectory, observation) ;
+            double latitude(trajectory, observation) ;
             ...
 
 Here we show how to inspect a file using cf-python which highlights the structure
@@ -264,17 +264,17 @@ described above:
         units = 'days since 1950-01-01 12:00:00.000000'
         Data(trajectory(2), observation(13)) = [[1950-01-06 00:00:00, ..., -275828-03-21 12:00:00]] 360_day
 
-    Auxiliary coordinate: lat
+    Auxiliary coordinate: latitude
         long_name = 'latitude'
         missing_value = np.float64(-999.9)
-        standard_name = 'lat'
+        standard_name = 'latitude'
         units = 'degrees_north'
         Data(trajectory(2), observation(13)) = [[-9.26, ..., nan]] degrees_north
 
-    Auxiliary coordinate: lon
+    Auxiliary coordinate: longitude
         long_name = 'longitude'
         missing_value = np.float64(-999.9)
-        standard_name = 'lon'
+        standard_name = 'longitude'
         units = 'degrees_east'
         Data(trajectory(2), observation(13)) = [[67.32, ..., nan]] degrees_east
 
@@ -298,8 +298,8 @@ explore cf-python, xarray, or `hurucanpy <https://huracanpy.readthedocs.io>`_.
     # Open the NetCDF file
     with netCDF4.Dataset("my_tctrack_output.nc") as ncfile:
         # Read variables
-        lat_var = ncfile.variables["lat"]
-        lon_var = ncfile.variables["lon"]
+        lat_var = ncfile.variables["latitude"]
+        lon_var = ncfile.variables["longitude"]
         time_var = ncfile.variables["time"]
         intensity_var = ncfile.variables["wind_speed"]
         traj_var = ncfile.variables["trajectory"]

--- a/src/tctrack/core/tracker.py
+++ b/src/tctrack/core/tracker.py
@@ -427,7 +427,7 @@ class TCTracker(ABC):
         lat_coord = cf.AuxiliaryCoordinate(
             data=lat_data,
             properties={
-                "standard_name": "lat",
+                "standard_name": "latitude",
                 "long_name": "latitude",
                 "units": "degrees_north",
                 "missing_value": lat_lon_fill,
@@ -444,7 +444,7 @@ class TCTracker(ABC):
         lon_coord = cf.AuxiliaryCoordinate(
             data=lon_data,
             properties={
-                "standard_name": "lon",
+                "standard_name": "longitude",
                 "long_name": "longitude",
                 "units": "degrees_east",
                 "missing_value": lat_lon_fill,

--- a/tests/unit/core/test_tracker.py
+++ b/tests/unit/core/test_tracker.py
@@ -340,8 +340,8 @@ class TestTCTracker:
 
         # Validate key coordinates like time, latitude, and longitude exist
         time_coord = field.construct("time")
-        lat_coord = field.construct("lat")
-        lon_coord = field.construct("lon")
+        lat_coord = field.construct("latitude")
+        lon_coord = field.construct("longitude")
         assert time_coord.shape == (trajectory_ids, observation_count)
         assert lat_coord.shape == lon_coord.shape == (trajectory_ids, observation_count)
 
@@ -380,14 +380,14 @@ class TestTCTracker:
 
         # Check the constructs (coordinates)
         expected_construct_metadata = {
-            "lat": {
-                "standard_name": "lat",
+            "latitude": {
+                "standard_name": "latitude",
                 "long_name": "latitude",
                 "units": "degrees_north",
                 "missing_value": -999.9,
             },
-            "lon": {
-                "standard_name": "lon",
+            "longitude": {
+                "standard_name": "longitude",
                 "long_name": "longitude",
                 "units": "degrees_east",
                 "missing_value": -999.9,

--- a/tests/unit/tempest_extremes/test_tempest_extremes.py
+++ b/tests/unit/tempest_extremes/test_tempest_extremes.py
@@ -637,8 +637,8 @@ class TestTETracker:
 
         # Validate key variables like time, latitude, and longitude
         time_coord = fields[0].construct("time")
-        lat_coord = fields[0].construct("lat")
-        lon_coord = fields[0].construct("lon")
+        lat_coord = fields[0].construct("latitude")
+        lon_coord = fields[0].construct("longitude")
 
         assert time_coord.shape == (trajectory_ids, observation_count)
         assert lat_coord.shape == lon_coord.shape == (trajectory_ids, observation_count)

--- a/tutorial/plot_tracks.py
+++ b/tutorial/plot_tracks.py
@@ -14,8 +14,8 @@ TCTRACK_DATA = "tracks_tempest_extremes.nc"
 # Open the NetCDF file
 with netCDF4.Dataset(TCTRACK_DATA) as ncfile:
     # Read variables
-    lat_var = ncfile.variables["lat"]
-    lon_var = ncfile.variables["lon"]
+    lat_var = ncfile.variables["latitude"]
+    lon_var = ncfile.variables["longitude"]
     time_var = ncfile.variables["time"]
     intensity_var = ncfile.variables["wind_speed"]
     traj_var = ncfile.variables["trajectory"]


### PR DESCRIPTION
This updates the CF standard name of longitude / latitude to be correct in the metadata (rather than `"lat"` and `"lon"` which are not valid aliases). It updates where this is set in `to_netcdf` and where it is tested.

Closes #169