### PR TITLE
Tracker module for ML based TC tracking algortihms

### DIFF
--- a/src/tctrack/core/ml_tracker.py
+++ b/src/tctrack/core/ml_tracker.py
@@ -1,0 +1,1 @@
+"""The module is a tracker for ML-based tropical cyclone tracking algorithms."""

--- a/src/tctrack/core/ml_tracker.py
+++ b/src/tctrack/core/ml_tracker.py
@@ -99,3 +99,12 @@ class TCMLTracker(TCTracker):
             model_file, map_location=parameters.device
         )
         self.model.eval()
+
+    @abstractmethod
+    def detect(self) -> None:
+        """Run the ML model on the preprocessed input to obtain TC candidates.
+
+        This method should populate the internal state (e.g. a list of
+        candidate detections) that can be used for reading trajectories or the stitching
+        step.
+        """

--- a/src/tctrack/core/ml_tracker.py
+++ b/src/tctrack/core/ml_tracker.py
@@ -1,8 +1,13 @@
 """Module providing abstract base classes for ML-based tracking algorithms."""
 
+import os
+from abc import abstractmethod
 from dataclasses import dataclass
 
-from .tracker import TCTrackerParameters
+import torch
+from huggingface_hub import hf_hub_download
+
+from .tracker import TCTracker, TCTrackerParameters
 
 
 @dataclass(repr=False)
@@ -38,3 +43,59 @@ class TCMLParameters(TCTrackerParameters):
         if not (0.0 <= self.threshold <= 1.0):
             msg = f"threshold must be in [0, 1], got {self.threshold}"
             raise ValueError(msg)
+
+
+class TCMLTracker(TCTracker):
+    """Abstract base class for ML-based tropical cyclone trackers.
+
+    Extends `TCTracker` functionality common to all
+    ML-based trackers e.g. loading a TorchScript model from
+    HuggingFace Hub repository, and the `detect` step.
+
+    Attributes
+    ----------
+    model : torch.jit.ScriptModule
+        The loaded TorchScript model in evaluation mode.
+    """
+
+    model: torch.jit.ScriptModule
+
+    @property
+    @abstractmethod
+    def _hf_filename(self) -> str:
+        """Filename of the model weights in the HuggingFace repository."""
+
+    def _load_model(self, parameters: TCMLParameters) -> None:
+        """Load the TorchScript model and set it to evaluation mode.
+
+        Loads model from TCMLParameters.model_path or downloads from HuggingFace Hub
+
+        Parameters
+        ----------
+        parameters : TCMLParameters
+            The parameter object containing model location and device type.
+
+        Raises
+        ------
+        OSError
+            If ``parameters.model_path`` is given but the file does not exist.
+        huggingface_hub.errors.RepositoryNotFoundError
+            If the HuggingFace repository cannot be found or accessed.
+        """
+        if parameters.model_path is not None:
+            if not os.path.exists(parameters.model_path):
+                msg = f"Model file not found: {parameters.model_path}"
+                raise OSError(msg)
+            model_file = parameters.model_path
+        else:
+            token = parameters.hf_token or os.environ.get("HF_TOKEN")
+            model_file = hf_hub_download(
+                repo_id=parameters.hf_repo_id,
+                filename=self._hf_filename,
+                token=token,
+            )
+
+        self.model: torch.jit.ScriptModule = torch.jit.load(
+            model_file, map_location=parameters.device
+        )
+        self.model.eval()

--- a/src/tctrack/core/ml_tracker.py
+++ b/src/tctrack/core/ml_tracker.py
@@ -1,1 +1,40 @@
-"""The module is a tracker for ML-based tropical cyclone tracking algorithms."""
+"""Module providing abstract base classes for ML-based tracking algorithms."""
+
+from dataclasses import dataclass
+
+from .tracker import TCTrackerParameters
+
+
+@dataclass(repr=False)
+class TCMLParameters(TCTrackerParameters):
+    """Base dataclass for parameters common to all ML-based trackers."""
+
+    model_path: str | None = None
+    """
+    Local path to the ``.pt`` model file. If ``None``, the model is downloaded
+    from the HuggingFace Hub repository given by :attr:`hf_repo_id`.
+    """
+
+    hf_repo_id: str = ""
+    """HuggingFace Hub repository ID from which the model is downloaded."""
+
+    hf_token: str | None = None
+    """
+    HuggingFace access token for the model repository. If ``None``, the value
+    of the ``HF_TOKEN`` environment variable is used instead.
+    """
+
+    device: str = "cpu"
+    """PyTorch device to run inference (e.g. ``"cpu"`` or ``"cuda"``)."""
+
+    threshold: float = 0.5
+    """
+    Confidence threshold for retaining detections. Candidates with a model
+    score below this value are discarded.
+    """
+
+    def __post_init__(self):
+        """Validate parameters."""
+        if not (0.0 <= self.threshold <= 1.0):
+            msg = f"threshold must be in [0, 1], got {self.threshold}"
+            raise ValueError(msg)

--- a/src/tctrack/core/ml_tracker.py
+++ b/src/tctrack/core/ml_tracker.py
@@ -4,6 +4,7 @@ import os
 from abc import abstractmethod
 from dataclasses import dataclass
 
+import scipy  # noqa: F401 
 import torch
 from huggingface_hub import hf_hub_download
 

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -6,10 +6,18 @@ References
   <https://tctrack.readthedocs.io/en/latest/developer/adding_algorithms.html>`__
 """
 
+import os
 from dataclasses import dataclass
 
+import cf
+import torch
+from huggingface_hub import hf_hub_download
+
 from tctrack.core import (
+    TCTracker,
+    TCTrackerMetadata,
     TCTrackerParameters,
+    Trajectory,
 )
 
 
@@ -55,3 +63,135 @@ class MLParameters(TCTrackerParameters):
         if not (0.0 <= self.threshold <= 1.0):
             msg = f"threshold must be in [0, 1], got {self.threshold}"
             raise ValueError(msg)
+
+
+class MLTracker(TCTracker):
+    """Class used to run the machine-learning cyclone tracking algorithm.
+
+    The model weights are loaded from a private HuggingFace Hub repository on
+    first use and cached locally by ``huggingface_hub``.
+
+    Attributes
+    ----------
+    parameters : MLParameters
+        Class containing the parameters for the tracking algorithm.
+    model : torch.nn.Module
+        The loaded PyTorch model in evaluation mode.
+
+    Examples
+    --------
+    >>> params = MLParameters(input_file="era5_2020.nc")
+    >>> tracker = MLTracker(params)
+    >>> tracker.run_tracker("trajectories.nc")
+    """
+
+    def __init__(self, parameters: MLParameters):
+        """Construct the MLTracker and load the model.
+
+        Parameters
+        ----------
+        parameters : MLParameters
+            Class containing the parameters for the tracking algorithm.
+
+        Raises
+        ------
+        OSError
+            If ``parameters.model_path`` is given but the file does not exist.
+        huggingface_hub.errors.RepositoryNotFoundError
+            If the HuggingFace repository cannot be found or accessed.
+        """
+        self.parameters: MLParameters = parameters
+        self._trajectories: list[Trajectory] = []
+
+        if parameters.model_path is not None:
+            model_file = parameters.model_path
+        else:
+            token = parameters.hf_token or os.environ.get("HF_TOKEN")
+            model_file = hf_hub_download(
+                repo_id=parameters.hf_repo_id,
+                filename="cyclone-detect-ml-scripted.pt",
+                token=token,
+            )
+
+        self.model: torch.jit.ScriptModule = torch.jit.load(
+            model_file, map_location=parameters.device
+        )
+        self.model.eval()
+
+    @property
+    def _parameters(self) -> list[TCTrackerParameters]:
+        """A list of the parameter objects accessible from the base class."""
+        return [self.parameters]
+
+    def read_trajectories(self) -> list[Trajectory]:
+        """Parse tracker outputs into a list of :class:`tctrack.core.Trajectory`.
+
+        Returns
+        -------
+        list[Trajectory]
+            A list of :class:`tctrack.core.Trajectory` objects.
+        """
+        return self._trajectories
+
+    def _set_metadata(self) -> None:
+        """Set the time and variable metadata attributes.
+
+        Raises
+        ------
+        ValueError
+            If a variable with time coordinate is not found in the input file.
+        """
+        vars_with_time = cf.read(self.parameters.input_file).select_by_construct("time")  # type: ignore[operator]
+        if len(vars_with_time) == 0:
+            msg = "No variable with 'time' coordinate found in the input file."
+            raise ValueError(msg)
+        time_coord = vars_with_time[0].coordinate("time")
+        self._time_metadata = {
+            "calendar": time_coord.calendar,
+            "units": time_coord.units,
+            "start_time": time_coord.data[0],
+            "end_time": time_coord.data[-1],
+        }
+
+        self._variable_metadata = {}
+        self._variable_metadata["variable_name"] = TCTrackerMetadata(
+            properties={
+                "standard_name": "...",
+                "long_name": "...",
+                "units": "...",
+            }
+        )
+
+    def detect(self) -> None:
+        """Run the ML detector and output the TC candidates."""
+
+    def run_tracker(self, output_file: str) -> None:
+        """Run the tracker to obtain the tropical cyclone trajectories.
+
+        This runs each of the individual steps of the tracking algorithm.
+
+        Finally, the output is saved as a CF-netCDF file by calling :meth:`to_netcdf`.
+        If the tracking algorithm doesn't produce an intermediate output file then the
+        trajectories should be passed to it as an argument.
+
+        Arguments
+        ---------
+        output_file : str
+            Filename to which the tropical cyclone track trajectories are saved.
+
+        Examples
+        --------
+        To set the parameters, instantiate a :class:`MLTracker` instance and run the
+        algorithm to generate trajectories:
+
+        >>> params = MLParameters(...)
+        >>> tracker = MLTracker(params)
+        >>> tracker.run_tracker("trajectories.nc")
+        """
+        # Run the steps for the tracking algorithm, eg:
+        # self.preprocess()
+        # self.detect()
+        # trajectories = self.stitch()
+
+        # Output the trajectories as a CF-netcdf file.
+        # self.to_netcdf(output_file, trajectories)

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -1,0 +1,57 @@
+"""Module providing a class to run a machine-learning tracking algorithm.
+
+References
+----------
+- `Instructions for adding a new tracker.
+  <https://tctrack.readthedocs.io/en/latest/developer/adding_algorithms.html>`__
+"""
+
+from dataclasses import dataclass
+
+from tctrack.core import (
+    TCTrackerParameters,
+)
+
+
+@dataclass(repr=False)
+class MLParameters(TCTrackerParameters):
+    """Dataclass containing values for parameters used by MLTracker.
+
+    See Also
+    --------
+    MLTracker : The tracker class that uses these parameters.
+    """
+
+    input_file: str
+    """CF-NetCDF file containing the input variables for the model."""
+
+    model_path: str | None = None
+    """
+    Local path to the ``.pt`` model file. If ``None``, the model is downloaded
+    from the HuggingFace Hub repository given by :attr:`hf_repo_id` and cached
+    locally by ``huggingface_hub``.
+    """
+
+    hf_repo_id: str = "surbhigoel456/cyclone-TC-ML"
+    """HuggingFace Hub repository ID from which the model is downloaded."""
+
+    hf_token: str | None = None
+    """
+    HuggingFace access token for the private model repository. If ``None``,
+    the value of the ``HF_TOKEN`` environment variable is used instead.
+    """
+
+    device: str = "cpu"
+    """PyTorch device on which to run inference (e.g. ``"cpu"`` or ``"cuda"``)."""
+
+    threshold: float = 0.5
+    """
+    Confidence threshold for retaining detections. Candidates with a model
+    score below this value are discarded.
+    """
+
+    def __post_init__(self):
+        """Validate parameters."""
+        if not (0.0 <= self.threshold <= 1.0):
+            msg = f"threshold must be in [0, 1], got {self.threshold}"
+            raise ValueError(msg)

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -6,19 +6,15 @@ References
   <https://tctrack.readthedocs.io/en/latest/developer/adding_algorithms.html>`__
 """
 
-import os
 from dataclasses import dataclass
 
 import cf
-import torch
-from huggingface_hub import hf_hub_download
 
 from tctrack.core import (
-    TCTracker,
     TCTrackerMetadata,
-    TCTrackerParameters,
     Trajectory,
 )
+from tctrack.core.ml_tracker import TCMLParameters, TCMLTracker
 
 
 @dataclass(repr=False)

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -35,6 +35,15 @@ class MLParameters(TCMLParameters):
     hf_repo_id: str = "surbhigoel456/cyclone-TC-ML"
     """HuggingFace Hub repository ID for the cyclone detection model."""
 
+    channels: tuple[str, ...] = ()
+    """CF variable names for the 17 input channels, in the order the model expects."""
+
+    patch_size: int = 32
+    """Spatial window size fed to the model (matches test_ml.py's 32x32 patches)."""
+
+    stride: int = 16
+    """Grid spacing between sampled patches."""
+
 
 class MLTracker(TCMLTracker):
     """Class used to run the machine-learning cyclone tracking algorithm.

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -6,9 +6,12 @@ References
   <https://tctrack.readthedocs.io/en/latest/developer/adding_algorithms.html>`__
 """
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import cf
+import numpy as np
+import torch
 
 from tctrack.core import (
     TCTrackerMetadata,
@@ -35,7 +38,7 @@ class MLParameters(TCMLParameters):
     hf_repo_id: str = "surbhigoel456/cyclone-TC-ML"
     """HuggingFace Hub repository ID for the cyclone detection model."""
 
-    channels: tuple[str, ...] = ()
+    channels: Sequence[str] = ()
     """CF variable names for the 17 input channels, in the order the model expects."""
 
     patch_size: int = 32
@@ -87,6 +90,7 @@ class MLTracker(TCMLTracker):
         """
         self.parameters: MLParameters = parameters
         self._trajectories: list[Trajectory] = []
+        self._scores: list[dict] = []
         self._load_model(parameters)
 
     @property
@@ -133,8 +137,29 @@ class MLTracker(TCMLTracker):
             }
         )
 
+    def preprocess(self) -> torch.Tensor:
+        """Stack the configured input channels into a single tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(channel, time, lat, lon)`` built from
+            :attr:`parameters.channels`, in that order.
+        """
+        fields = cf.read(self.parameters.input_file)
+        arrays = [fields.select_field(name).array for name in self.parameters.channels]
+        self._lats = fields[0].coordinate("latitude").array
+        self._lons = fields[0].coordinate("longitude").array
+        self._times = fields[0].coordinate("time").datetime_array
+        return torch.from_numpy(np.stack(arrays, axis=0)).float()
+
     def detect(self) -> None:
-        """Run the ML detector and output the TC candidates."""
+        """Run the ML model over the grid and record a score for every patch.
+
+        Every patch is scored and stored in :attr:`_scores`, not just those
+        above :attr:`parameters.threshold`, so the raw scores remain available
+        for evaluation (e.g. ROC/AUC) as well as for candidate selection.
+        """
 
     def run_tracker(self, output_file: str) -> None:
         """Run the tracker to obtain the tropical cyclone trajectories.

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -18,47 +18,22 @@ from tctrack.core.ml_tracker import TCMLParameters, TCMLTracker
 
 
 @dataclass(repr=False)
-class MLParameters(TCTrackerParameters):
+class MLParameters(TCMLParameters):
     """Dataclass containing values for parameters used by MLTracker.
+
+    Extends :class:`~tctrack.core.ml_tracker.TCMLParameters` with the input
+    file path and sets the default HuggingFace repository for this model.
 
     See Also
     --------
     MLTracker : The tracker class that uses these parameters.
     """
 
-    input_file: str
+    input_file: str = ""
     """CF-NetCDF file containing the input variables for the model."""
 
-    model_path: str | None = None
-    """
-    Local path to the ``.pt`` model file. If ``None``, the model is downloaded
-    from the HuggingFace Hub repository given by :attr:`hf_repo_id` and cached
-    locally by ``huggingface_hub``.
-    """
-
     hf_repo_id: str = "surbhigoel456/cyclone-TC-ML"
-    """HuggingFace Hub repository ID from which the model is downloaded."""
-
-    hf_token: str | None = None
-    """
-    HuggingFace access token for the private model repository. If ``None``,
-    the value of the ``HF_TOKEN`` environment variable is used instead.
-    """
-
-    device: str = "cpu"
-    """PyTorch device on which to run inference (e.g. ``"cpu"`` or ``"cuda"``)."""
-
-    threshold: float = 0.5
-    """
-    Confidence threshold for retaining detections. Candidates with a model
-    score below this value are discarded.
-    """
-
-    def __post_init__(self):
-        """Validate parameters."""
-        if not (0.0 <= self.threshold <= 1.0):
-            msg = f"threshold must be in [0, 1], got {self.threshold}"
-            raise ValueError(msg)
+    """HuggingFace Hub repository ID for the cyclone detection model."""
 
 
 class MLTracker(TCTracker):

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -36,18 +36,18 @@ class MLParameters(TCMLParameters):
     """HuggingFace Hub repository ID for the cyclone detection model."""
 
 
-class MLTracker(TCTracker):
+class MLTracker(TCMLTracker):
     """Class used to run the machine-learning cyclone tracking algorithm.
 
-    The model weights are loaded from a private HuggingFace Hub repository on
-    first use and cached locally by ``huggingface_hub``.
+    The model weights are loaded from a HuggingFace Hub repository on first
+    use and cached locally by ``huggingface_hub``.
 
     Attributes
     ----------
     parameters : MLParameters
         Class containing the parameters for the tracking algorithm.
-    model : torch.nn.Module
-        The loaded PyTorch model in evaluation mode.
+    model : torch.jit.ScriptModule
+        The loaded TorchScript model in evaluation mode.
 
     Examples
     --------
@@ -55,6 +55,11 @@ class MLTracker(TCTracker):
     >>> tracker = MLTracker(params)
     >>> tracker.run_tracker("trajectories.nc")
     """
+
+    @property
+    def _hf_filename(self) -> str:
+        """Filename of the model weights in the HuggingFace repository."""
+        return "cyclone-detect-ml-scripted.pt"
 
     def __init__(self, parameters: MLParameters):
         """Construct the MLTracker and load the model.
@@ -73,24 +78,10 @@ class MLTracker(TCTracker):
         """
         self.parameters: MLParameters = parameters
         self._trajectories: list[Trajectory] = []
-
-        if parameters.model_path is not None:
-            model_file = parameters.model_path
-        else:
-            token = parameters.hf_token or os.environ.get("HF_TOKEN")
-            model_file = hf_hub_download(
-                repo_id=parameters.hf_repo_id,
-                filename="cyclone-detect-ml-scripted.pt",
-                token=token,
-            )
-
-        self.model: torch.jit.ScriptModule = torch.jit.load(
-            model_file, map_location=parameters.device
-        )
-        self.model.eval()
+        self._load_model(parameters)
 
     @property
-    def _parameters(self) -> list[TCTrackerParameters]:
+    def _parameters(self) -> list[MLParameters]:
         """A list of the parameter objects accessible from the base class."""
         return [self.parameters]
 

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -450,12 +450,13 @@ class MLTracker(TCMLTracker):
         self._scores = []
         self._candidates = []
         with torch.no_grad():
-            for t in range(n_time):
+            for t in range(n_time): #Loop runs once per timestep until all timesteps have been processed 
                 frame = data[:, t, :, :].unsqueeze(0)  # (1, channel, lat, lon)
-                output = self.model(frame)  # (1, 5, lat', lon')
+                output = self.model(frame)  # (1, 5, lat', lon') #Inference to get the predicted class probabilities for each pixel in the input frame.
                 probs = torch.softmax(output, dim=1)[0].numpy()  # (5, lat', lon')
 
-                if probs.shape[1:] != (len(self._lats), len(self._lons)):
+                #Check if the output grid matches input grid
+                if probs.shape[1:] != (len(self._lats), len(self._lons)): 
                     msg = (
                         f"Model output shape {probs.shape[1:]} does not match "
                         f"the input grid {(len(self._lats), len(self._lons))}."
@@ -464,7 +465,7 @@ class MLTracker(TCMLTracker):
 
                 for i, lat in enumerate(self._lats):
                     for j, lon in enumerate(self._lons):
-                        self._scores.append(
+                        self._scores.append( #scores list collects the time, lat, lon and the predicted class probabilities for each pixel in the input frame.
                             {
                                 "time": self._times[t],
                                 "lat": float(lat),
@@ -472,10 +473,11 @@ class MLTracker(TCMLTracker):
                                 "probs": probs[:, i, j].tolist(),
                             }
                         )
-
-                # Reduce this timestep's pixels to discrete storm locations.
-                class_idx = probs.argmax(axis=0)
-                class_prob = probs.max(axis=0)
+                # Pick the winning class and confidence for each pixel
+                class_idx = probs.argmax(axis=0) #WHICH class won: 0-4
+                class_prob = probs.max(axis=0) #HOW high it was: 0.0-1.0
+                
+                #check if the winning class is a storm
                 is_storm = (class_idx != 0) & (class_prob >= self.parameters.threshold)
 
                 candidates = self._cluster_candidates(is_storm, class_idx, class_prob)
@@ -498,7 +500,10 @@ class MLTracker(TCMLTracker):
         class_prob: np.ndarray,
     ) -> list[dict]:
         """Group adjacent same-class detected pixels into single point candidates.
-
+        It happens through flood-fill, where each unclaimed storm pixel is used as a seed
+        to find all its adjacent pixels of the same class, and then 
+        the centroid of that blob is calculated using the class confidence as weights.
+        
         Parameters
         ----------
         is_storm : numpy.ndarray
@@ -515,17 +520,20 @@ class MLTracker(TCMLTracker):
             and ``score`` - the probability-weighted centroid, class, and
             peak probability of each connected group of same-class pixels.
         """
-        unvisited = set(zip(*np.nonzero(is_storm), strict=False))
-        candidates = []
+        unvisited = set(zip(*np.nonzero(is_storm), strict=False)) #storm classified pixels that are still unclaimed by any blob.
+        candidates = [] #list to carry details of candidate storms (centroid lat-lon) for each timestep
 
-        while unvisited:
-            start = unvisited.pop()
+        # Run the loop until no pixels are left unchecked.
+        while unvisited: 
+            #start with an arbitrary unclaimed storm pixel
+            start = unvisited.pop() # pop() removes and returns the element from the right end 
             component_class = class_idx[start]
-            queue = deque([start])
+            queue = deque([start]) #collection of pixels whose neigbours are yet to be checked
             pixels = [start]
-
+            
+            # Run the loop until no neigbouring pixel is left unchecked for a blob
             while queue:
-                y, x = queue.popleft()
+                y, x = queue.popleft() # popleft() removes and returns an element from the left end of the deque
                 for dy, dx in ((-1, 0), (1, 0), (0, -1), (0, 1)):
                     neighbour = (y + dy, x + dx)
                     if (
@@ -538,13 +546,13 @@ class MLTracker(TCMLTracker):
 
             ys, xs = zip(*pixels, strict=False)
             ys_arr, xs_arr = np.array(ys), np.array(xs)
-            weights = class_prob[ys_arr, xs_arr]
+            weights = class_prob[ys_arr, xs_arr] #Use class confidence as weights for the centroid calculation
             candidates.append(
                 {
-                    "lat": float(np.average(self._lats[ys_arr], weights=weights)),
-                    "lon": float(np.average(self._lons[xs_arr], weights=weights)),
-                    "class_index": float(component_class),
-                    "score": float(weights.max()),
+                    "lat": float(np.average(self._lats[ys_arr], weights=weights)), #averaged pixel specific-latitudes to get centroid latitude of the storm
+                    "lon": float(np.average(self._lons[xs_arr], weights=weights)), #averaged pixel specific-longitudes to get centroid longitude of the storm
+                    "class_index": float(component_class), #the class index of the storm (1-4)
+                    "score": float(weights.max()), #the maximum confidence value within the bloc (between 0 and 1)
                 }
             )
 
@@ -563,16 +571,16 @@ class MLTracker(TCMLTracker):
         list[dict]
             The retained candidates, strongest first.
         """
-        if self.parameters.merge_distance_deg <= 0:
+        if self.parameters.merge_distance_deg <= 0: 
             return candidates
 
-        kept: list[dict] = []
-        for candidate in sorted(candidates, key=lambda c: c["score"], reverse=True):
+        kept: list[dict] = [] #list that will hold the strongest candidates after eliminating the weaker ones that are too close to each other.
+        for candidate in sorted(candidates, key=lambda c: c["score"], reverse=True): #
             if all(
-                np.hypot(
-                    candidate["lat"] - other["lat"], candidate["lon"] - other["lon"]
+                np.hypot(#calculate distance between centroids of different candidates.
+                    candidate["lat"] - other["lat"], candidate["lon"] - other["lon"] 
                 )
-                >= self.parameters.merge_distance_deg
+                >= self.parameters.merge_distance_deg #compare the centroid distance with the merge distance threshold to decide if the candidate is too close to any of the already kept candidates.
                 for other in kept
             ):
                 kept.append(candidate)

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -243,12 +243,43 @@ class MLTracker(TCMLTracker):
         return torch.from_numpy(data).float()
 
     def detect(self) -> None:
-        """Run the ML model over the grid and record a score for every patch.
+        """Run the U-Net over the grid and save per-pixel class probabilities.
 
-        Every patch is scored and stored in :attr:`_scores`, not just those
-        above :attr:`parameters.threshold`, so the raw scores remain available
-        for evaluation (e.g. ROC/AUC) as well as for candidate selection.
+        Raises
+        ------
+        ValueError
+            If the model's output spatial shape doesn't match the input
+            file's latitude/longitude grid, it would indicate a bug.
         """
+        data = self.preprocess()  # (channel, time, lat, lon)
+        _, n_time, _, _ = data.shape
+
+        out_lats, out_lons = self._lats, self._lons
+
+        self._scores = []
+        with torch.no_grad():
+            for t in range(n_time):
+                frame = data[:, t, :, :].unsqueeze(0)  # (1, channel, lat, lon)
+                output = self.model(frame)  # (1, 5, lat', lon')
+                probs = torch.softmax(output, dim=1)[0].numpy()  # (5, lat', lon')
+
+                if probs.shape[1:] != (len(out_lats), len(out_lons)):
+                    msg = (
+                        f"Model output shape {probs.shape[1:]} does not match "
+                        f"the input grid {(len(out_lats), len(out_lons))}."
+                    )
+                    raise ValueError(msg)
+
+                for i, lat in enumerate(out_lats):
+                    for j, lon in enumerate(out_lons):
+                        self._scores.append(
+                            {
+                                "time": self._times[t],
+                                "lat": float(lat),
+                                "lon": float(lon),
+                                "probs": probs[:, i, j].tolist(),
+                            }
+                        )
 
     def run_tracker(self, output_file: str) -> None:
         """Run the tracker to obtain the tropical cyclone trajectories.

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -10,10 +10,13 @@ from collections import deque
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+import warnings
+
 import cf
 import h5py
 import numpy as np
 import torch
+from cftime import date2num
 
 from tctrack.core import (
     TCTrackerMetadata,
@@ -628,6 +631,114 @@ class MLTracker(TCMLTracker):
             if trajectory.observations >= self.parameters.stitch_min_length
         ]
         return self._trajectories
+
+    def detections_to_netcdf(self, output_file: str) -> None:
+        """Write the detected TC locations to a CF-compliant NetCDF point file.
+
+        The detections from :meth:`detect` are a set of independent points -
+        each a storm location at one time, with the input variables sampled
+        there - rather than connected tracks. They are therefore written with
+        ``featureType = "point"`` over a single ``observation`` dimension,
+        instead of the trajectory layout :meth:`to_netcdf` produces.
+
+        Parameters
+        ----------
+        output_file : str
+            Filename for the output NetCDF file. Placed in the working
+            directory unless a full path is given.
+
+        Warns
+        -----
+        UserWarning
+            If :meth:`detect` found no candidates, in which case no file is
+            written.
+
+        References
+        ----------
+        `CF-Conventions - H.1. Point Data
+        <https://cfconventions.org/Data/cf-conventions/cf-conventions-1.11/cf-conventions.html#point-data>`_
+        """
+        if not self._time_metadata or not self._variable_metadata:
+            self.set_metadata()
+
+        if not self._candidates:
+            msg = (
+                "There are no detections to write, so no output file will be "
+                "created. Has detect() been run?"
+            )
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
+            return
+
+        domain_axis = cf.DomainAxis(size=len(self._candidates))
+        domain_axis.nc_set_dimension("observation")
+        dim_obs = cf.DimensionCoordinate(
+            data=cf.Data(range(len(self._candidates))),
+            properties={
+                "standard_name": "observation",
+                "long_name": "detection index",
+            },
+        )
+
+        time_coord = cf.AuxiliaryCoordinate(
+            data=cf.Data(
+                date2num(
+                    [candidate["time"] for candidate in self._candidates],
+                    units=self.time_metadata["units"],
+                    calendar=self.time_metadata["calendar"],
+                ).tolist()
+            ),
+            properties={
+                "standard_name": "time",
+                "long_name": "time of detection",
+                "units": cf.Units(
+                    self.time_metadata["units"], calendar=self.time_metadata["calendar"]
+                ),
+            },
+        )
+        lat_coord = cf.AuxiliaryCoordinate(
+            data=cf.Data([candidate["lat"] for candidate in self._candidates]),
+            properties={
+                "standard_name": "latitude",
+                "long_name": "latitude of detection",
+                "units": "degrees_north",
+            },
+        )
+        lon_coord = cf.AuxiliaryCoordinate(
+            data=cf.Data([candidate["lon"] for candidate in self._candidates]),
+            properties={
+                "standard_name": "longitude",
+                "long_name": "longitude of detection",
+                "units": "degrees_east",
+            },
+        )
+
+        fields = []
+        for variable in self._candidates[0]:
+            if variable in {"time", "lat", "lon"}:
+                continue
+
+            metadata = self.variable_metadata.get(variable, TCTrackerMetadata({}))
+            metadata.properties["featureType"] = "point"
+            field = cf.Field(properties=metadata.properties)
+            if "standard_name" not in metadata.properties:
+                field.nc_set_variable(variable)
+
+            axis = field.set_construct(domain_axis)
+            field.set_construct(dim_obs, axes=(axis,))
+            field.set_construct(time_coord, axes=(axis,))
+            field.set_construct(lat_coord, axes=(axis,))
+            field.set_construct(lon_coord, axes=(axis,))
+            field.set_data(
+                cf.Data([candidate[variable] for candidate in self._candidates]),
+                axes=(axis,),
+            )
+
+            if self.global_metadata:
+                field.nc_set_global_attributes(self.global_metadata)
+
+            fields.append(field)
+
+        cf.write(fields, output_file)  # type: ignore[operator]
 
     def run_tracker(self, output_file: str) -> None:
         """Run the tracker to obtain the tropical cyclone trajectories.

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -309,6 +309,57 @@ class MLTracker(TCMLTracker):
 
         return torch.from_numpy(data).float()
 
+    @property
+    def _channel_names(self) -> list[str]:
+        """Names for the model's input channels, in the order they are stacked.
+
+        Matches the loop in :meth:`preprocess`: each pressure variable at each
+        pressure level (variable-major), then the land/sea mask, then sea
+        surface temperature.
+        """
+        names = [
+            f"{variable}_{int(level)}"
+            for variable in self.parameters.pressure_variables
+            for level in self.parameters.pressure_levels
+        ]
+        return [*names, "land_mask", "sea_surface_temperature"]
+
+    def _colocated_variables(
+        self,
+        frame: np.ndarray,
+        candidate: dict,
+        mean: np.ndarray,
+        value_range: np.ndarray,
+    ) -> dict:
+        """Sample the input variables at a candidate's location.
+
+        Values are taken at the grid point nearest the candidate's reported
+        position and converted back to physical units, undoing the
+        ``(x - mean) / range`` scaling applied in :meth:`preprocess` so that
+        what is reported is e.g. a temperature in Kelvin rather than a
+        normalised number.
+
+        Parameters
+        ----------
+        frame : numpy.ndarray
+            This timestep's normalised input, shape ``(channel, lat, lon)``.
+        candidate : dict
+            A candidate with ``lat``/``lon`` keys.
+        mean : numpy.ndarray
+            Per-channel means used to normalise, shape ``(channel,)``.
+        value_range : numpy.ndarray
+            Per-channel ranges used to normalise, shape ``(channel,)``.
+
+        Returns
+        -------
+        dict
+            One entry per input channel, keyed by :attr:`_channel_names`.
+        """
+        i = int(np.argmin(np.abs(self._lats - candidate["lat"])))
+        j = int(np.argmin(np.abs(self._lons - candidate["lon"])))
+        physical = frame[:, i, j] * value_range + mean
+        return dict(zip(self._channel_names, physical.tolist(), strict=True))
+
     def detect(self) -> None:
         """Run the U-Net over the grid and locate the tropical cyclones in it.
 
@@ -332,6 +383,10 @@ class MLTracker(TCMLTracker):
         """
         data = self.preprocess()  # (channel, time, lat, lon)
         _, n_time, _, _ = data.shape
+
+        # Reused to convert the normalised input back to physical units when
+        # recording the variables co-located with each detection.
+        mean, value_range = self._load_normalisation_stats()
 
         self._scores = []
         self._candidates = []
@@ -366,8 +421,15 @@ class MLTracker(TCMLTracker):
 
                 candidates = self._cluster_candidates(is_storm, class_idx, class_prob)
                 candidates = self._merge_nearby_candidates(candidates)
+
+                frame_data = data[:, t, :, :].numpy()  # (channel, lat, lon)
                 for candidate in candidates:
                     candidate["time"] = self._times[t]
+                    candidate.update(
+                        self._colocated_variables(
+                            frame_data, candidate, mean, value_range
+                        )
+                    )
                 self._candidates.extend(candidates)
 
     def _cluster_candidates(

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -447,16 +447,88 @@ class MLTracker(TCMLTracker):
             :attr:`parameters.stitch_max_distance_deg`, or ``None`` if none
             qualify.
         """
-        best_index, best_distance = None, self.parameters.stitch_max_distance_deg
+        best_index, best_distance = None, self.parameters.stitch_max_distance_deg #best distance is closest distance found so far
         for i in unmatched:
             candidate = candidates[i]
             distance = np.hypot(
                 candidate["lat"] - track["last"]["lat"],
                 candidate["lon"] - track["last"]["lon"],
             )
-            if distance < best_distance:
+            if distance < best_distance: #condition to check if the distance is less than the best distance found so far
                 best_index, best_distance = i, distance
         return best_index
+    
+    def stitch(self) -> list[Trajectory]:
+        """Link per-timestep detections into cyclone trajectories.
+
+        Returns
+        -------
+        list[Trajectory]
+            One :class:`~tctrack.core.Trajectory` per track with at least
+            :attr:`parameters.stitch_min_length` observations.
+        """
+        n_lat, n_lon = len(self._lats), len(self._lons)
+        n_per_frame = n_lat * n_lon
+
+
+        active_tracks: list[dict] = [] #list of dictionaries with trajectories, location of last storm point, missed timesteps
+        finished: list[Trajectory] = [] #list of dictionaries with trajectories that have been completed and no longer active
+        next_id = 0
+
+
+        for t, time in enumerate(self._times):
+            frame = self._scores[t * n_per_frame : (t + 1) * n_per_frame]
+            probs = np.array([point["probs"] for point in frame]).reshape(
+                n_lat, n_lon, -1
+            )
+            class_idx = probs.argmax(axis=-1)
+            class_prob = probs.max(axis=-1)
+            is_storm = (class_idx != 0) & (class_prob >= self.parameters.threshold) #check if pixel is storm and clears the confidence threshold 
+
+
+            candidates = self._cluster_candidates(is_storm, class_idx, class_prob) #calls clustering function
+            candidates = self._merge_nearby_candidates(candidates) #calls merge candidates function
+
+            #set of pixels that are not yet matched to a track, used to avoid double-counting candidates
+            unmatched = set(range(len(candidates)))
+            for track in active_tracks:
+                match = self._nearest_candidate(track, candidates, unmatched) #calls nearest candidate check function.
+                if match is None:
+                    track["missed"] += 1
+                    continue
+                point = candidates[match]
+                track["traj"].add_point(time, point)
+                track["last"] = point
+                track["missed"] = 0
+                unmatched.discard(match)
+
+
+            still_active = []
+            for track in active_tracks:
+                if track["missed"] > self.parameters.stitch_max_gap:
+                    finished.append(track["traj"])
+                else:
+                    still_active.append(track)
+            active_tracks = still_active
+
+
+            for i in unmatched:
+                point = candidates[i]
+                trajectory = Trajectory(next_id, time)
+                trajectory.add_point(time, point)
+                active_tracks.append(
+                    {"traj": trajectory, "last": point, "missed": 0}
+                )
+                next_id += 1
+
+
+        finished.extend(track["traj"] for track in active_tracks)
+        self._trajectories = [
+            trajectory
+            for trajectory in finished
+            if trajectory.observations >= self.parameters.stitch_min_length
+        ]
+        return self._trajectories
 
     def run_tracker(self, output_file: str) -> None:
         """Run the tracker to obtain the tropical cyclone trajectories.

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -82,6 +82,18 @@ class MLParameters(TCMLParameters):
     raises rather than silently passing unnormalised data to the model.
     """
 
+    merge_distance_deg: float = 2.0
+    """Distance (degrees lat/lon) within which candidates in the same timestep
+    are merged, keeping only the highest-scoring one.
+
+    The model often splits a single storm into several adjacent clusters -
+    either side of a lifecycle-class boundary, or where confidence dips below
+    :attr:`~TCMLParameters.threshold` mid-storm - which would otherwise each
+    become a separate track. Mirrors ``merge_dist`` in TempestExtremes'
+    ``DetectNodes``, which resolves the same problem for its own candidates.
+    Set to ``0`` to disable merging.
+    """
+
     stitch_max_distance_deg: float = 3.0
     """Maximum distance (degrees lat/lon) between a track's last point and a
     candidate in the next timestep for them to be linked as the same storm.
@@ -146,6 +158,10 @@ class MLTracker(TCMLTracker):
         self.parameters: MLParameters = parameters
         self._trajectories: list[Trajectory] = []
         self._scores: list[dict] = []
+        # Grid/time coordinates of the input file, populated by preprocess().
+        self._lats: np.ndarray = np.array([])
+        self._lons: np.ndarray = np.array([])
+        self._times: np.ndarray = np.array([])
         self._load_model(parameters)
 
     @property
@@ -255,7 +271,7 @@ class MLTracker(TCMLTracker):
         for variable in self.parameters.pressure_variables:
             field = fields.select_field(variable)
             for level in self.parameters.pressure_levels:
-                pressure_channels.append(field.subspace(Z=level).squeeze().array)
+                pressure_channels.append(field.subspace(Z=level).squeeze("Z").array)
 
         sst = fields.select_field(self.parameters.sst_variable).array
         t2m = fields.select_field(self.parameters.t2m_variable).array
@@ -293,8 +309,6 @@ class MLTracker(TCMLTracker):
         data = self.preprocess()  # (channel, time, lat, lon)
         _, n_time, _, _ = data.shape
 
-        out_lats, out_lons = self._lats, self._lons
-
         self._scores = []
         with torch.no_grad():
             for t in range(n_time):
@@ -302,15 +316,15 @@ class MLTracker(TCMLTracker):
                 output = self.model(frame)  # (1, 5, lat', lon')
                 probs = torch.softmax(output, dim=1)[0].numpy()  # (5, lat', lon')
 
-                if probs.shape[1:] != (len(out_lats), len(out_lons)):
+                if probs.shape[1:] != (len(self._lats), len(self._lons)):
                     msg = (
                         f"Model output shape {probs.shape[1:]} does not match "
-                        f"the input grid {(len(out_lats), len(out_lons))}."
+                        f"the input grid {(len(self._lats), len(self._lons))}."
                     )
                     raise ValueError(msg)
 
-                for i, lat in enumerate(out_lats):
-                    for j, lon in enumerate(out_lons):
+                for i, lat in enumerate(self._lats):
+                    for j, lon in enumerate(self._lons):
                         self._scores.append(
                             {
                                 "time": self._times[t],
@@ -319,6 +333,93 @@ class MLTracker(TCMLTracker):
                                 "probs": probs[:, i, j].tolist(),
                             }
                         )
+
+    def _cluster_candidates(
+        self,
+        is_storm: np.ndarray,
+        class_idx: np.ndarray,
+        class_prob: np.ndarray,
+    ) -> list[dict]:
+        """Group adjacent same-class detected pixels into single point candidates.
+
+        Parameters
+        ----------
+        is_storm : numpy.ndarray
+            Boolean array, shape ``(lat, lon)``, True for detected pixels.
+        class_idx : numpy.ndarray
+            Winning class index per pixel, shape ``(lat, lon)``.
+        class_prob : numpy.ndarray
+            Winning class probability per pixel, shape ``(lat, lon)``.
+
+        Returns
+        -------
+        list[dict]
+            One dict per cluster with keys ``lat``, ``lon``, ``class_index``,
+            and ``score`` - the probability-weighted centroid, class, and
+            peak probability of each connected group of same-class pixels.
+        """
+        unvisited = set(zip(*np.nonzero(is_storm), strict=False))
+        candidates = []
+
+        while unvisited:
+            start = unvisited.pop()
+            component_class = class_idx[start]
+            queue = deque([start])
+            pixels = [start]
+
+            while queue:
+                y, x = queue.popleft()
+                for dy, dx in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+                    neighbour = (y + dy, x + dx)
+                    if (
+                        neighbour in unvisited
+                        and class_idx[neighbour] == component_class
+                    ):
+                        unvisited.discard(neighbour)
+                        queue.append(neighbour)
+                        pixels.append(neighbour)
+
+            ys, xs = zip(*pixels, strict=False)
+            ys_arr, xs_arr = np.array(ys), np.array(xs)
+            weights = class_prob[ys_arr, xs_arr]
+            candidates.append(
+                {
+                    "lat": float(np.average(self._lats[ys_arr], weights=weights)),
+                    "lon": float(np.average(self._lons[xs_arr], weights=weights)),
+                    "class_index": float(component_class),
+                    "score": float(weights.max()),
+                }
+            )
+
+        return candidates
+
+    def _merge_nearby_candidates(self, candidates: list[dict]) -> list[dict]:
+        """Merges candidates that are too close together into the strongest one.
+
+        Parameters
+        ----------
+        candidates : list[dict]
+            This timestep's candidates, as built by :meth:`_cluster_candidates`.
+
+        Returns
+        -------
+        list[dict]
+            The retained candidates, strongest first.
+        """
+        if self.parameters.merge_distance_deg <= 0:
+            return candidates
+
+        kept: list[dict] = []
+        for candidate in sorted(candidates, key=lambda c: c["score"], reverse=True):
+            if all(
+                np.hypot(
+                    candidate["lat"] - other["lat"], candidate["lon"] - other["lon"]
+                )
+                >= self.parameters.merge_distance_deg
+                for other in kept
+            ):
+                kept.append(candidate)
+        return kept
 
     def run_tracker(self, output_file: str) -> None:
         """Run the tracker to obtain the tropical cyclone trajectories.

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -394,7 +394,7 @@ class MLTracker(TCMLTracker):
         return candidates
 
     def _merge_nearby_candidates(self, candidates: list[dict]) -> list[dict]:
-        """Merges candidates that are too close together into the strongest one.
+        """Merge candidates that are too close together into the strongest one.
 
         Parameters
         ----------
@@ -420,6 +420,43 @@ class MLTracker(TCMLTracker):
             ):
                 kept.append(candidate)
         return kept
+
+    def _nearest_candidate(
+        self,
+        track: dict,
+        candidates: list[dict],
+        unmatched: set[int],
+    ) -> int | None:
+        """Find the closest unmatched candidate to a track's last point.
+
+        Parameters
+        ----------
+        track : dict
+            Active track state, with a ``last`` dict holding its most recent
+            ``lat``/``lon``.
+        candidates : list[dict]
+            This timestep's candidate detections, as built by
+            :meth:`_cluster_candidates`.
+        unmatched : set[int]
+            Indices into ``candidates`` not yet claimed this timestep.
+
+        Returns
+        -------
+        int | None
+            Index of the nearest candidate within
+            :attr:`parameters.stitch_max_distance_deg`, or ``None`` if none
+            qualify.
+        """
+        best_index, best_distance = None, self.parameters.stitch_max_distance_deg
+        for i in unmatched:
+            candidate = candidates[i]
+            distance = np.hypot(
+                candidate["lat"] - track["last"]["lat"],
+                candidate["lon"] - track["last"]["lon"],
+            )
+            if distance < best_distance:
+                best_index, best_distance = i, distance
+        return best_index
 
     def run_tracker(self, output_file: str) -> None:
         """Run the tracker to obtain the tropical cyclone trajectories.

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -22,6 +22,16 @@ from tctrack.core import (
 from tctrack.core.ml_tracker import TCMLParameters, TCMLTracker
 
 
+def _point_variables(candidate: dict) -> dict:
+    """Strip a candidate down to the numeric variables of a trajectory point.
+
+    Candidates carry the timestep they were found at, but
+    :meth:`~tctrack.core.Trajectory.add_point` takes the time separately and
+    requires every remaining value to be numeric, so it is dropped here.
+    """
+    return {key: value for key, value in candidate.items() if key != "time"}
+
+
 @dataclass(repr=False)
 class MLParameters(TCMLParameters):
     """Dataclass containing values for parameters used by MLTracker.
@@ -158,6 +168,8 @@ class MLTracker(TCMLTracker):
         self.parameters: MLParameters = parameters
         self._trajectories: list[Trajectory] = []
         self._scores: list[dict] = []
+        # TC locations found by detect(), consumed by stitch().
+        self._candidates: list[dict] = []
         # Grid/time coordinates of the input file, populated by preprocess().
         self._lats: np.ndarray = np.array([])
         self._lons: np.ndarray = np.array([])
@@ -298,7 +310,19 @@ class MLTracker(TCMLTracker):
         return torch.from_numpy(data).float()
 
     def detect(self) -> None:
-        """Run the U-Net over the grid and save per-pixel class probabilities.
+        """Run the U-Net over the grid and locate the tropical cyclones in it.
+
+        For each timestep the model is run, its per-pixel class probabilities
+        are thresholded, and the surviving pixels are grouped into discrete
+        candidate storms (see :meth:`_cluster_candidates` and
+        :meth:`_merge_nearby_candidates`). The result is a list of TC
+        locations on :attr:`_candidates`, which :meth:`stitch` then links into
+        trajectories - mirroring how the other TCTrack trackers split the work,
+        where detection emits candidate points and stitching consumes them.
+
+        The full per-pixel probabilities are also kept on :attr:`_scores`,
+        which retains the per-class detail that thresholding discards (useful
+        for evaluation, e.g. one-vs-rest ROC per lifecycle class).
 
         Raises
         ------
@@ -310,6 +334,7 @@ class MLTracker(TCMLTracker):
         _, n_time, _, _ = data.shape
 
         self._scores = []
+        self._candidates = []
         with torch.no_grad():
             for t in range(n_time):
                 frame = data[:, t, :, :].unsqueeze(0)  # (1, channel, lat, lon)
@@ -333,6 +358,17 @@ class MLTracker(TCMLTracker):
                                 "probs": probs[:, i, j].tolist(),
                             }
                         )
+
+                # Reduce this timestep's pixels to discrete storm locations.
+                class_idx = probs.argmax(axis=0)
+                class_prob = probs.max(axis=0)
+                is_storm = (class_idx != 0) & (class_prob >= self.parameters.threshold)
+
+                candidates = self._cluster_candidates(is_storm, class_idx, class_prob)
+                candidates = self._merge_nearby_candidates(candidates)
+                for candidate in candidates:
+                    candidate["time"] = self._times[t]
+                self._candidates.extend(candidates)
 
     def _cluster_candidates(
         self,
@@ -459,7 +495,16 @@ class MLTracker(TCMLTracker):
         return best_index
     
     def stitch(self) -> list[Trajectory]:
-        """Link per-timestep detections into cyclone trajectories.
+        """Link the TC locations found by :meth:`detect` into trajectories.
+
+        Consumes the candidates on :attr:`_candidates`, working through the
+        timesteps in order and, at each one, extending existing tracks with a
+        nearby candidate, retiring tracks that have gone unmatched for too
+        long, and starting new tracks from whatever is left over.
+
+        The result is also stored on :attr:`_trajectories`, so that
+        :meth:`read_trajectories` - and therefore :meth:`to_netcdf` - can
+        reach it.
 
         Returns
         -------
@@ -467,29 +512,21 @@ class MLTracker(TCMLTracker):
             One :class:`~tctrack.core.Trajectory` per track with at least
             :attr:`parameters.stitch_min_length` observations.
         """
-        n_lat, n_lon = len(self._lats), len(self._lons)
-        n_per_frame = n_lat * n_lon
-
+        # Group detect()'s flat list of locations by the timestep they belong
+        # to, so each timestep's candidates can be looked up by index below.
+        by_timestep: dict = {time: [] for time in self._times}
+        for candidate in self._candidates:
+            by_timestep[candidate["time"]].append(candidate)
 
         active_tracks: list[dict] = [] #list of dictionaries with trajectories, location of last storm point, missed timesteps
         finished: list[Trajectory] = [] #list of dictionaries with trajectories that have been completed and no longer active
         next_id = 0
 
 
-        for t, time in enumerate(self._times):
-            frame = self._scores[t * n_per_frame : (t + 1) * n_per_frame]
-            probs = np.array([point["probs"] for point in frame]).reshape(
-                n_lat, n_lon, -1
-            )
-            class_idx = probs.argmax(axis=-1)
-            class_prob = probs.max(axis=-1)
-            is_storm = (class_idx != 0) & (class_prob >= self.parameters.threshold) #check if pixel is storm and clears the confidence threshold 
+        for time in self._times:
+            candidates = by_timestep[time]
 
-
-            candidates = self._cluster_candidates(is_storm, class_idx, class_prob) #calls clustering function
-            candidates = self._merge_nearby_candidates(candidates) #calls merge candidates function
-
-            #set of pixels that are not yet matched to a track, used to avoid double-counting candidates
+            #set of candidates that are not yet matched to a track, used to avoid double-counting them
             unmatched = set(range(len(candidates)))
             for track in active_tracks:
                 match = self._nearest_candidate(track, candidates, unmatched) #calls nearest candidate check function.
@@ -497,7 +534,7 @@ class MLTracker(TCMLTracker):
                     track["missed"] += 1
                     continue
                 point = candidates[match]
-                track["traj"].add_point(time, point)
+                track["traj"].add_point(time, _point_variables(point))
                 track["last"] = point
                 track["missed"] = 0
                 unmatched.discard(match)
@@ -515,7 +552,7 @@ class MLTracker(TCMLTracker):
             for i in unmatched:
                 point = candidates[i]
                 trajectory = Trajectory(next_id, time)
-                trajectory.add_point(time, point)
+                trajectory.add_point(time, _point_variables(point))
                 active_tracks.append(
                     {"traj": trajectory, "last": point, "missed": 0}
                 )

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -38,14 +38,38 @@ class MLParameters(TCMLParameters):
     hf_repo_id: str = "surbhigoel456/cyclone-TC-ML"
     """HuggingFace Hub repository ID for the cyclone detection model."""
 
-    channels: Sequence[str] = ()
-    """CF variable names for the 17 input channels, in the order the model expects."""
+    pressure_variables: Sequence[str] = (
+        "relative_humidity",
+        "temperature",
+        "u_component_of_wind",
+        "v_component_of_wind",
+        "vorticity",
+    )
+    """CF identities of the pressure-level input variables, in model channel order.
 
-    patch_size: int = 32
-    """Spatial window size fed to the model (matches test_ml.py's 32x32 patches)."""
+    Matches ``pressure_var_codes`` in the reference training pipeline
+    (`cyclone-track-ml <https://github.com/robert-edwin-rouse/cyclone-track-ml>`__).
+    """
 
-    stride: int = 16
-    """Grid spacing between sampled patches."""
+    pressure_levels: Sequence[float] = (1000, 750, 500)
+    """Pressure levels (hPa) to extract for each of :attr:`pressure_variables`."""
+
+    sst_variable: str = "sea_surface_temperature"
+    """CF identity of the sea surface temperature variable."""
+
+    t2m_variable: str = "2m_temperature"
+    """CF identity of the 2-metre temperature variable, used to gap-fill SST over land."""
+
+    normalisation_stats_path: str | None = None
+    """Path to an ``.npz`` file with per-channel ``mean`` and ``range`` arrays
+    (each shape ``(channel,)``, ordered as in :meth:`MLTracker.preprocess`),
+    used to normalise input as ``(x - mean) / range``.
+
+    These must be the statistics computed over the model's *training* set
+    (see ``compiler.py`` in the reference training pipeline); they cannot be
+    recomputed from a single inference file. If ``None``, :meth:`MLTracker.preprocess`
+    raises rather than silently passing unnormalised data to the model.
+    """
 
 
 class MLTracker(TCMLTracker):
@@ -137,21 +161,86 @@ class MLTracker(TCMLTracker):
             }
         )
 
+    def _load_normalisation_stats(self) -> tuple[np.ndarray, np.ndarray]:
+        """Load per-channel normalisation statistics.
+
+        Returns
+        -------
+        tuple[numpy.ndarray, numpy.ndarray]
+            ``(mean, range)`` arrays, each of shape ``(channel,)``, ordered to
+            match the channel stack built by :meth:`preprocess`.
+
+        Raises
+        ------
+        ValueError
+            If :attr:`parameters.normalisation_stats_path` is not set.
+
+        Notes
+        -----
+        Placeholder for loading the trained model's actual
+        training-set statistics.
+        """
+        if self.parameters.normalisation_stats_path is None:
+            msg = (
+                "parameters.normalisation_stats_path must be set to normalise "
+                "model input - see MLTracker.preprocess."
+            )
+            raise ValueError(msg)
+        stats = np.load(self.parameters.normalisation_stats_path)
+        return stats["mean"], stats["range"]
+
     def preprocess(self) -> torch.Tensor:
-        """Stack the configured input channels into a single tensor.
+        """Build the model input tensor from the configured ERA5 variables.
+
+        Reproduces the channel layout the model was trained on: each of
+        parameters.pressure_variables at each of
+        parameters.pressure_levels,
+        followed by a land/sea mask, followed by sea surface
+        temperature gap-filled with 2-metre temperature over land. Channels
+        are then normalised using _load_normalisation_stats.
 
         Returns
         -------
         torch.Tensor
-            Tensor of shape ``(channel, time, lat, lon)`` built from
-            :attr:`parameters.channels`, in that order.
+            Tensor of shape ``(channel, time, lat, lon)``, normalised.
+
+        Raises
+        ------
+        ValueError
+            If a configured variable cannot be found in the input file, or if
+            :attr:`parameters.normalisation_stats_path` is not set.
         """
         fields = cf.read(self.parameters.input_file)
-        arrays = [fields.select_field(name).array for name in self.parameters.channels]
+
+        pressure_channels = []
+        for variable in self.parameters.pressure_variables:
+            field = fields.select_field(variable)
+            for level in self.parameters.pressure_levels:
+                pressure_channels.append(field.subspace(Z=level).squeeze().array)
+
+        sst = fields.select_field(self.parameters.sst_variable).array
+        t2m = fields.select_field(self.parameters.t2m_variable).array
+
+        # Static land/sea mask: SST is undefined over land. Taken from the first
+        # timestep and held fixed, matching the reference preprocessing.
+        land_mask = np.broadcast_to(
+            np.ma.getmaskarray(sst)[0].astype(np.float32), sst.shape
+        )
+
+        # Gap-fill SST over land with 2m air temperature, as in training.
+        sst_filled = np.where(np.ma.getmaskarray(sst), t2m, np.ma.filled(sst, 0.0))
+
+        channels = [*pressure_channels, land_mask, sst_filled]
+
         self._lats = fields[0].coordinate("latitude").array
         self._lons = fields[0].coordinate("longitude").array
         self._times = fields[0].coordinate("time").datetime_array
-        return torch.from_numpy(np.stack(arrays, axis=0)).float()
+
+        data = np.stack(channels, axis=0)
+        mean, value_range = self._load_normalisation_stats()
+        data = (data - mean[:, None, None, None]) / value_range[:, None, None, None]
+
+        return torch.from_numpy(data).float()
 
     def detect(self) -> None:
         """Run the ML model over the grid and record a score for every patch.

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -6,10 +6,12 @@ References
   <https://tctrack.readthedocs.io/en/latest/developer/adding_algorithms.html>`__
 """
 
+from collections import deque
 from collections.abc import Sequence
 from dataclasses import dataclass
 
 import cf
+import h5py
 import numpy as np
 import torch
 
@@ -40,35 +42,64 @@ class MLParameters(TCMLParameters):
 
     pressure_variables: Sequence[str] = (
         "relative_humidity",
-        "temperature",
-        "u_component_of_wind",
-        "v_component_of_wind",
-        "vorticity",
+        "air_temperature",
+        "eastward_wind",
+        "northward_wind",
+        "atmosphere_relative_vorticity",
     )
     """CF identities of the pressure-level input variables, in model channel order.
 
-    Matches ``pressure_var_codes`` in the reference training pipeline
-    (`cyclone-track-ml <https://github.com/robert-edwin-rouse/cyclone-track-ml>`__).
+    Correspond to ``pressure_var_codes`` in the reference training pipeline
+    (`cyclone-track-ml <https://github.com/robert-edwin-rouse/cyclone-track-ml>`__),
+    but given as the actual CF ``standard_name`` each variable is converted to
+    (via cfgrib) in ERA5 output, which differs from the CDS API request name
+    used there for several variables (e.g. ``"temperature"`` in the reference
+    pipeline is ``"air_temperature"`` here).
     """
 
     pressure_levels: Sequence[float] = (1000, 750, 500)
     """Pressure levels (hPa) to extract for each of :attr:`pressure_variables`."""
 
-    sst_variable: str = "sea_surface_temperature"
-    """CF identity of the sea surface temperature variable."""
+    sst_variable: str = "ncvar%sst"
+    """CF identity of the sea surface temperature variable.
 
-    t2m_variable: str = "2m_temperature"
+    ERA5 sea surface temperature has no ``standard_name`` (cfgrib leaves it
+    ``"unknown"``), so it must be selected by NetCDF variable name instead.
+    """
+
+    t2m_variable: str = "ncvar%t2m"
     """CF identity of the 2-metre temperature variable, used to gap-fill SST over land."""
 
     normalisation_stats_path: str | None = None
-    """Path to an ``.npz`` file with per-channel ``mean`` and ``range`` arrays
+    """Path to a ``.nc`` file with per-channel ``mean`` and ``range`` variables
     (each shape ``(channel,)``, ordered as in :meth:`MLTracker.preprocess`),
     used to normalise input as ``(x - mean) / range``.
 
-    These must be the statistics computed over the model's *training* set
-    (see ``compiler.py`` in the reference training pipeline); they cannot be
-    recomputed from a single inference file. If ``None``, :meth:`MLTracker.preprocess`
+    These must be the statistics computed over the model's *training* set;
+    they cannot be recomputed from a single inference file. Matches the
+    ``data/normalisation_parameters.nc`` file saved by ``compiler.py`` in the
+    reference training pipeline. If ``None``, :meth:`MLTracker.preprocess`
     raises rather than silently passing unnormalised data to the model.
+    """
+
+    stitch_max_distance_deg: float = 3.0
+    """Maximum distance (degrees lat/lon) between a track's last point and a
+    candidate in the next timestep for them to be linked as the same storm.
+
+    Not part of the reference training pipeline, which only trains
+    per-pixel classification and has no timestep-to-timestep linking step.
+    The default assumes 6-hourly input (as used for training) and typical
+    cyclone translation speeds; reduce for higher-frequency input.
+    """
+
+    stitch_max_gap: int = 1
+    """Number of consecutive timesteps a track may go unmatched before it is
+    closed, tolerating brief drops below :attr:`~TCMLParameters.threshold`.
+    """
+
+    stitch_min_length: int = 2
+    """Minimum number of observations a track must have to be kept, filtering
+    out single-timestep detections likely to be noise.
     """
 
 
@@ -164,6 +195,17 @@ class MLTracker(TCMLTracker):
     def _load_normalisation_stats(self) -> tuple[np.ndarray, np.ndarray]:
         """Load per-channel normalisation statistics.
 
+        Reads the ``mean``/``range`` variables from the ``.nc`` file produced
+        by ``compiler.py`` in the reference training pipeline
+        (``data/normalisation_parameters.nc``). Uses ``h5py`` rather than
+        ``cf.read`` - this file's variables carry inherited GRIB/cfgrib
+        attributes (e.g. an auxiliary ``number`` coordinate) that make
+        ``cfdm`` build them through a data-creation path requiring a lazy
+        ``scipy`` import; in this environment that import fails once
+        ``torch`` has already been loaded (a ``libstdc++`` version conflict
+        between the two), which ``h5py`` - already a TCTrack dependency -
+        avoids entirely by reading the plain arrays directly.
+
         Returns
         -------
         tuple[numpy.ndarray, numpy.ndarray]
@@ -174,11 +216,6 @@ class MLTracker(TCMLTracker):
         ------
         ValueError
             If :attr:`parameters.normalisation_stats_path` is not set.
-
-        Notes
-        -----
-        Placeholder for loading the trained model's actual
-        training-set statistics.
         """
         if self.parameters.normalisation_stats_path is None:
             msg = (
@@ -186,8 +223,10 @@ class MLTracker(TCMLTracker):
                 "model input - see MLTracker.preprocess."
             )
             raise ValueError(msg)
-        stats = np.load(self.parameters.normalisation_stats_path)
-        return stats["mean"], stats["range"]
+        with h5py.File(self.parameters.normalisation_stats_path, "r") as stats:
+            mean = stats["mean"][:]
+            value_range = stats["range"][:]
+        return mean, value_range
 
     def preprocess(self) -> torch.Tensor:
         """Build the model input tensor from the configured ERA5 variables.

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -6,12 +6,11 @@ References
   <https://tctrack.readthedocs.io/en/latest/developer/adding_algorithms.html>`__
 """
 
+import itertools
+import warnings
 from collections import deque
 from collections.abc import Sequence
 from dataclasses import dataclass
-
-import itertools
-import warnings
 
 import cf
 import h5py
@@ -256,10 +255,11 @@ class MLTracker(TCMLTracker):
             self.parameters.pressure_variables, self.parameters.pressure_levels
         ):
             standard_name, units = colocated_metadata[variable]
+            described = standard_name.replace("_", " ")
             self._variable_metadata[f"{variable}_{int(level)}"] = TCTrackerMetadata(
                 properties={
                     "standard_name": standard_name,
-                    "long_name": f"{standard_name.replace('_', ' ')} at {int(level)} hPa",
+                    "long_name": f"{described} at {int(level)} hPa",
                     "units": units,
                 }
             )
@@ -802,11 +802,13 @@ class MLTracker(TCMLTracker):
     def run_tracker(self, output_file: str) -> None:
         """Run the tracker to obtain the tropical cyclone trajectories.
 
-        This runs each of the individual steps of the tracking algorithm.
+        Runs :meth:`detect` to locate the cyclones at each timestep - which
+        reads and prepares the input itself, via :meth:`preprocess` - then
+        links those detections into tracks with :meth:`stitch`, and finally
+        writes the tracks out with :meth:`to_netcdf`.
 
-        Finally, the output is saved as a CF-netCDF file by calling :meth:`to_netcdf`.
-        If the tracking algorithm doesn't produce an intermediate output file then the
-        trajectories should be passed to it as an argument.
+        The detections behind those tracks can be saved separately, as CF
+        point data, with :meth:`detections_to_netcdf`.
 
         Arguments
         ---------
@@ -822,10 +824,6 @@ class MLTracker(TCMLTracker):
         >>> tracker = MLTracker(params)
         >>> tracker.run_tracker("trajectories.nc")
         """
-        # Run the steps for the tracking algorithm, eg:
-        # self.preprocess()
-        # self.detect()
-        # trajectories = self.stitch()
-
-        # Output the trajectories as a CF-netcdf file.
-        # self.to_netcdf(output_file, trajectories)
+        self.detect()
+        self.stitch()
+        self.to_netcdf(output_file)

--- a/src/tctrack/machine_learning/cyclone_track_ml.py
+++ b/src/tctrack/machine_learning/cyclone_track_ml.py
@@ -10,6 +10,7 @@ from collections import deque
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+import itertools
 import warnings
 
 import cf
@@ -207,19 +208,74 @@ class MLTracker(TCMLTracker):
             msg = "No variable with 'time' coordinate found in the input file."
             raise ValueError(msg)
         time_coord = vars_with_time[0].coordinate("time")
+        # datetime_array, not data, so these are cftime.datetime objects as
+        # TCTrackerTimeMetadata requires - to_netcdf compares them against a
+        # timedelta, which fails on the cf.Data that .data returns.
+        datetimes = time_coord.datetime_array
         self._time_metadata = {
             "calendar": time_coord.calendar,
             "units": time_coord.units,
-            "start_time": time_coord.data[0],
-            "end_time": time_coord.data[-1],
+            "start_time": datetimes[0],
+            "end_time": datetimes[-1],
         }
 
-        self._variable_metadata = {}
-        self._variable_metadata["variable_name"] = TCTrackerMetadata(
+        # CF metadata for everything a detection or trajectory point carries:
+        # the model's own two outputs, then the input variables sampled at the
+        # storm location (see MLTracker._channel_names).
+        self._variable_metadata = {
+            "class_index": TCTrackerMetadata(
+                properties={
+                    "long_name": "tropical cyclone lifecycle stage",
+                    "units": "1",
+                    # Categorical, so described with CF flag attributes rather
+                    # than a standard name. Matches config.lifestages in the
+                    # reference training pipeline, with 0 for background.
+                    "flag_values": [0, 1, 2, 3, 4],
+                    "flag_meanings": (
+                        "background storm_nondeveloping cyclolysis "
+                        "cyclogenesis active_cyclone"
+                    ),
+                }
+            ),
+            "score": TCTrackerMetadata(
+                properties={
+                    "long_name": "model confidence in the assigned lifecycle stage",
+                    "units": "1",
+                }
+            ),
+        }
+
+        colocated_metadata = {
+            "relative_humidity": ("relative_humidity", "%"),
+            "air_temperature": ("air_temperature", "K"),
+            "eastward_wind": ("eastward_wind", "m s-1"),
+            "northward_wind": ("northward_wind", "m s-1"),
+            "atmosphere_relative_vorticity": ("atmosphere_relative_vorticity", "s-1"),
+        }
+        for variable, level in itertools.product(
+            self.parameters.pressure_variables, self.parameters.pressure_levels
+        ):
+            standard_name, units = colocated_metadata[variable]
+            self._variable_metadata[f"{variable}_{int(level)}"] = TCTrackerMetadata(
+                properties={
+                    "standard_name": standard_name,
+                    "long_name": f"{standard_name.replace('_', ' ')} at {int(level)} hPa",
+                    "units": units,
+                }
+            )
+
+        self._variable_metadata["land_mask"] = TCTrackerMetadata(
             properties={
-                "standard_name": "...",
-                "long_name": "...",
-                "units": "...",
+                "standard_name": "land_binary_mask",
+                "long_name": "land/sea mask, 1 over land",
+                "units": "1",
+            }
+        )
+        self._variable_metadata["sea_surface_temperature"] = TCTrackerMetadata(
+            properties={
+                "standard_name": "sea_surface_temperature",
+                "long_name": "sea surface temperature, gap-filled over land",
+                "units": "K",
             }
         )
 
@@ -720,8 +776,11 @@ class MLTracker(TCMLTracker):
             metadata = self.variable_metadata.get(variable, TCTrackerMetadata({}))
             metadata.properties["featureType"] = "point"
             field = cf.Field(properties=metadata.properties)
-            if "standard_name" not in metadata.properties:
-                field.nc_set_variable(variable)
+            # Always name the NetCDF variable explicitly. Several variables
+            # legitimately share a standard name (the same quantity at
+            # different pressure levels), and cf-python would otherwise derive
+            # the variable name from it and collide.
+            field.nc_set_variable(variable)
 
             axis = field.set_construct(domain_axis)
             field.set_construct(dim_obs, axes=(axis,))

--- a/tests/integration/test_integration_ml_pipeline.py
+++ b/tests/integration/test_integration_ml_pipeline.py
@@ -1,18 +1,27 @@
-"""Integration test for the MLTracker pipeline: preprocess -> detect -> stitch.
+"""Integration test for the MLTracker pipeline.
 
-A small crop of real ERA5 data is run through preprocess() -> detect() ->
-stitch(), checking shapes and invariants at each step. Finding zero storms is
-an acceptable outcome.
+Runs a small crop of real ERA5 data through preprocess() -> detect() ->
+stitch(), then writes the results with both output writers and reads them
+back. Shapes and invariants are checked at each step; how *well* the model
+detects storms is deliberately not asserted on, since it is trained on full
+721x1440 global fields and behaves unreliably on crops this small.
 
 Everything is built fresh on every run - the ERA5 crop is re-cut from the
 source files and the statistics re-fetched from the reference repo, into a
-temporary directory that is discarded afterwards. Kept small deliberately: a 32x32 crop over 2 timesteps. Two timesteps is the
+temporary directory that is discarded afterwards. Nothing is cached, so the
+test can never pass against stale inputs.
+
+Kept small deliberately: a 32x32 crop over 2 timesteps. Two timesteps is the
 minimum that exercises cross-timestep track linking, and 32x32 is the smallest
 safe size given the U-Net downsamples by 16.
 
 Run from the repo root with:
     conda run -n tctrack-env python tests/integration/test_integration_ml_pipeline.py
 """
+
+# The test inspects the tracker's internal state on purpose - that is what it
+# is verifying - so private-member access is expected throughout.
+# ruff: noqa: SLF001
 
 import subprocess
 import tempfile
@@ -35,7 +44,6 @@ MODEL_PATH = (
 )
 
 # Small and cheap: 32x32 grid points over 2 consecutive 6-hourly timesteps.
-# Two timesteps is the minimum that exercises cross-timestep track linking.
 CENTRE_LAT, CENTRE_LON = -12.6, 51.0
 HALF_BOX = 16
 TIME_START, N_TIME = 40, 2
@@ -47,6 +55,25 @@ N_CLASSES = 5
 # a winning probability can be as low as ~0.21 - so the output writers are
 # exercised at a lower threshold, purely so that there is something to write.
 LOW_THRESHOLD = 0.2
+
+RULE = "-" * 66
+
+
+def section(title: str) -> None:
+    """Print a titled section header."""
+    print(f"\n{RULE}\n{title}\n{RULE}")
+
+
+def make_tracker(input_file: str, stats_file: str, **overrides) -> MLTracker:
+    """Build a tracker against the prepared inputs, overriding any parameter."""
+    return MLTracker(
+        MLParameters(
+            input_file=input_file,
+            model_path=MODEL_PATH,
+            normalisation_stats_path=stats_file,
+            **overrides,
+        )
+    )
 
 
 def build_era5_input(input_file: str) -> None:
@@ -89,31 +116,21 @@ def build_era5_input(input_file: str) -> None:
 
 def fetch_norm_stats(stats_file: str) -> None:
     """Pull the real normalisation statistics from the reference repo."""
-    subprocess.run(["git", "fetch", "origin"], cwd=REFERENCE_REPO, check=True)
+    git = ["git", "-C", REFERENCE_REPO]
+    subprocess.run([*git, "fetch", "origin"], check=True)  # noqa: S603
     with open(stats_file, "wb") as handle:
-        subprocess.run(
-            ["git", "show", REFERENCE_STATS_REF],
-            cwd=REFERENCE_REPO,
-            stdout=handle,
-            check=True,
+        subprocess.run(  # noqa: S603
+            [*git, "show", REFERENCE_STATS_REF], stdout=handle, check=True
         )
     print(f"  fetched statistics from {REFERENCE_STATS_REF}")
 
 
-def test_real_data(input_file: str, stats_file: str) -> None:
-    """Run the real pipeline and check every step is structurally sound."""
-    print("\n" + "-" * 66)
-    print("real ERA5 data through preprocess -> detect -> stitch")
-    print("-" * 66)
+def test_pipeline(input_file: str, stats_file: str) -> None:
+    """Run the pipeline at default settings and check each step's output."""
+    section("real ERA5 data through preprocess -> detect -> stitch")
 
-    params = MLParameters(
-        input_file=input_file,
-        model_path=MODEL_PATH,
-        normalisation_stats_path=stats_file,
-    )
-    tracker = MLTracker(params)
+    tracker = make_tracker(input_file, stats_file)
 
-    # -- preprocess --------------------------------------------------------
     tensor = tracker.preprocess()
     n_lat, n_lon = len(tracker._lats), len(tracker._lons)
     assert tuple(tensor.shape) == (N_CHANNELS, N_TIME, n_lat, n_lon), (
@@ -123,30 +140,29 @@ def test_real_data(input_file: str, stats_file: str) -> None:
     assert len(tracker._times) == N_TIME, "wrong number of timesteps read"
     print(f"  preprocess(): {tuple(tensor.shape)}, no NaNs                    OK")
 
-    # -- detect ------------------------------------------------------------
     tracker.detect()
     expected = N_TIME * n_lat * n_lon
     assert len(tracker._scores) == expected, (
         f"expected {expected} scores, got {len(tracker._scores)}"
     )
-    for score in tracker._scores[:100]:
-        assert set(score) == {"time", "lat", "lon", "probs"}, "unexpected score keys"
-        assert len(score["probs"]) == N_CLASSES, "expected 5 class probabilities"
-    sums = np.array([sum(s["probs"]) for s in tracker._scores])
+    # detect() builds every score in one loop, so checking one covers the shape.
+    assert set(tracker._scores[0]) == {"time", "lat", "lon", "probs"}
+    assert len(tracker._scores[0]["probs"]) == N_CLASSES
+    sums = np.array([sum(score["probs"]) for score in tracker._scores])
     assert np.abs(sums - 1.0).max() < 1e-4, "softmax outputs must sum to 1"
-    detected = sum(1 for s in tracker._scores if int(np.argmax(s["probs"])) != 0)
+    detected = sum(
+        1 for score in tracker._scores if int(np.argmax(score["probs"])) != 0
+    )
     print(f"  detect():     {len(tracker._scores)} scores, softmax valid       OK")
     print(f"                {detected} non-background pixels (not asserted on)")
 
-    # -- stitch ------------------------------------------------------------
     trajectories = tracker.stitch()
-    assert isinstance(trajectories, list), "stitch() must return a list"
     assert tracker.read_trajectories() == trajectories, (
         "read_trajectories() must return what stitch() produced, else to_netcdf() "
         "would write nothing"
     )
     for trajectory in trajectories:
-        assert trajectory.observations >= params.stitch_min_length
+        assert trajectory.observations >= tracker.parameters.stitch_min_length
         for key in ("time", "lat", "lon"):
             assert key in trajectory.data, f"trajectory missing '{key}'"
     print(f"  stitch():     {len(trajectories)} trajectories, all well-formed   OK")
@@ -154,62 +170,58 @@ def test_real_data(input_file: str, stats_file: str) -> None:
         print("                (none found - fine, model quality is not under test)")
 
 
-def test_outputs(work_dir: str, input_file: str, stats_file: str) -> None:
-    """Check both output writers produce readable CF-NetCDF files.
+def test_output_writers(work_dir: str, input_file: str, stats_file: str) -> None:
+    """Check both writers produce readable CF-NetCDF files.
 
     Uses a lowered threshold so that detections actually exist: at the default
     the model finds nothing in this small window, and the writers would take
     their empty-input path without the file-writing code ever running.
     """
-    print("\n" + "-" * 66)
-    print("output writers: detections_to_netcdf() and to_netcdf()")
-    print("-" * 66)
+    section("output writers: detections_to_netcdf() and to_netcdf()")
 
-    tracker = MLTracker(
-        MLParameters(
-            input_file=input_file,
-            model_path=MODEL_PATH,
-            normalisation_stats_path=stats_file,
-            threshold=LOW_THRESHOLD,
-            stitch_min_length=1,  # keep single-timestep tracks, so tracks exist
-        )
+    tracker = make_tracker(
+        input_file,
+        stats_file,
+        threshold=LOW_THRESHOLD,
+        stitch_min_length=1,  # keep single-timestep tracks, so tracks exist
     )
     tracker.detect()
     trajectories = tracker.stitch()
     assert tracker._candidates, (
-        f"no detections even at threshold={LOW_THRESHOLD}; the writers below "
-        "cannot be exercised"
+        f"no detections even at threshold={LOW_THRESHOLD}, so the writers "
+        "below cannot be exercised"
     )
     assert trajectories, "no trajectories to write"
-    print(f"  {len(tracker._candidates)} detections, {len(trajectories)} trajectories to write")
+    print(
+        f"  {len(tracker._candidates)} detections, "
+        f"{len(trajectories)} trajectories to write"
+    )
 
     # -- detections: CF point layout ---------------------------------------
     detections_file = f"{work_dir}/detections.nc"
     tracker.detections_to_netcdf(detections_file)
     fields = cf.read(detections_file)
-
     written = {field.nc_get_variable("?"): field for field in fields}
+
     assert len(written) == len(fields), "netCDF variable names collided"
     for required in ("class_index", "score", "sea_surface_temperature"):
         assert required in written, f"{required} missing from the detections file"
-    assert written["sea_surface_temperature"].get_property("standard_name") == (
-        "sea_surface_temperature"
-    ), "co-located variables should carry a CF standard name"
+
+    sst = written["sea_surface_temperature"]
+    assert sst.get_property("standard_name") == "sea_surface_temperature", (
+        "co-located variables should carry a CF standard name"
+    )
     assert written["class_index"].get_property("flag_meanings"), (
         "the categorical class should carry CF flag attributes"
     )
-
-    example = next(iter(written.values()))
-    assert example.get_property("featureType") == "point", (
+    assert sst.get_property("featureType") == "point", (
         "detections are points, not trajectories"
     )
     for coordinate in ("time", "latitude", "longitude"):
-        assert example.coordinate(coordinate) is not None, f"missing {coordinate}"
+        assert sst.coordinate(coordinate) is not None, f"missing {coordinate}"
 
-    # values should survive the round trip unchanged
-    from_file = written["sea_surface_temperature"].array.tolist()
     in_memory = [c["sea_surface_temperature"] for c in tracker._candidates]
-    assert np.allclose(from_file, in_memory), "values changed on write/read"
+    assert np.allclose(sst.array.tolist(), in_memory), "values changed on write/read"
     print(f"  detections_to_netcdf(): {len(fields)} variables, point layout    OK")
 
     # -- trajectories: CF trajectory layout --------------------------------
@@ -218,15 +230,17 @@ def test_outputs(work_dir: str, input_file: str, stats_file: str) -> None:
     track_fields = cf.read(tracks_file)
     assert track_fields, "trajectory file has no variables"
     assert track_fields[0].get_property("featureType") == "trajectory"
-    print(f"  to_netcdf():            {len(track_fields)} variables, trajectory layout OK")
+    print(
+        f"  to_netcdf():            {len(track_fields)} variables, "
+        "trajectory layout OK"
+    )
 
 
 def main() -> None:
     """Run the integration test against freshly prepared real data."""
-    print("=" * 66)
-    print("MLTracker pipeline integration test")
-    print("(checks the code works; does NOT judge model accuracy)")
-    print("=" * 66)
+    banner = "=" * 66
+    print(f"{banner}\nMLTracker pipeline integration test")
+    print(f"(checks the code works; does NOT judge model accuracy)\n{banner}")
 
     # Fresh temporary directory per run, removed on exit.
     with tempfile.TemporaryDirectory(prefix="tctrack_ml_test_") as work_dir:
@@ -235,12 +249,10 @@ def main() -> None:
         build_era5_input(input_file)
         fetch_norm_stats(stats_file)
 
-        test_real_data(input_file, stats_file)
-        test_outputs(work_dir, input_file, stats_file)
+        test_pipeline(input_file, stats_file)
+        test_output_writers(work_dir, input_file, stats_file)
 
-    print("\n" + "=" * 66)
-    print("ALL CHECKS PASSED")
-    print("=" * 66)
+    print(f"\n{banner}\nALL CHECKS PASSED\n{banner}")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_integration_ml_pipeline.py
+++ b/tests/integration/test_integration_ml_pipeline.py
@@ -1,0 +1,175 @@
+"""Integration test for the MLTracker pipeline: preprocess -> detect -> stitch.
+
+A small crop of real ERA5 data is run through preprocess() -> detect() ->
+stitch(), checking shapes and invariants at each step. Finding zero storms is
+an acceptable outcome.
+
+Everything is built fresh on every run - the ERA5 crop is re-cut from the
+source files and the statistics re-fetched from the reference repo, into a
+temporary directory that is discarded afterwards. Kept small deliberately: a 32x32 crop over 2 timesteps. Two timesteps is the
+minimum that exercises cross-timestep track linking, and 32x32 is the smallest
+safe size given the U-Net downsamples by 16.
+
+Run from the repo root with:
+    conda run -n tctrack-env python tests/integration/test_integration_ml_pipeline.py
+"""
+
+import subprocess
+import tempfile
+
+import cf
+import numpy as np
+
+from tctrack.machine_learning.cyclone_track_ml import MLParameters, MLTracker
+
+RDS_DIR = "/home/sg2147/rds/rds-inspire-tc-TqEGHMWTn8A/sg2147"
+PRESSURE_FILE = f"{RDS_DIR}/era5_pressure_2025_1.nc"
+SURFACE_FILE = f"{RDS_DIR}/era5_surface_2025_1.nc"
+
+REFERENCE_REPO = "/home/sg2147/tc-track/cyclone-track-ml"
+REFERENCE_STATS_REF = "origin/main:data/normalisation_parameters.nc"
+
+MODEL_PATH = (
+    "/home/sg2147/.cache/huggingface/hub/models--surbhigoel456--cyclone-TC-ML/"
+    "snapshots/529eccbf13ee27056e2f01ec6bd06163133e8923/cyclone-detect-ml-scripted.pt"
+)
+
+# Small and cheap: 32x32 grid points over 2 consecutive 6-hourly timesteps.
+# Two timesteps is the minimum that exercises cross-timestep track linking.
+CENTRE_LAT, CENTRE_LON = -12.6, 51.0
+HALF_BOX = 16
+TIME_START, N_TIME = 40, 2
+
+N_CHANNELS = 17
+N_CLASSES = 5
+
+
+def build_era5_input(input_file: str) -> None:
+    """Build the tracker's input file from the real ERA5 source files.
+
+    Cuts a small window out of the pressure and surface files and merges them
+    into one file, since MLTracker expects a single input containing every
+    variable it needs, while the ERA5 downloads keep them separate.
+    """
+    print("  reading real ERA5 files...")
+    params = MLParameters()
+
+    # One read of each source file, reused for both the coordinate lookup and
+    # the field extraction - these files are several GB each.
+    pressure_fields = cf.read(PRESSURE_FILE)
+    surface_fields = cf.read(SURFACE_FILE)
+
+    reference = pressure_fields.select_field(params.pressure_variables[0])
+    lats = reference.coordinate("latitude").array
+    lons = reference.coordinate("longitude").array
+    lat_idx = int(np.argmin(np.abs(lats - CENTRE_LAT)))
+    lon_idx = int(np.argmin(np.abs(lons - CENTRE_LON)))
+
+    lat_slice = slice(lat_idx - HALF_BOX, lat_idx + HALF_BOX)
+    lon_slice = slice(lon_idx - HALF_BOX, lon_idx + HALF_BOX)
+    time_slice = slice(TIME_START, TIME_START + N_TIME)
+
+    fields = [
+        pressure_fields.select_field(variable)[time_slice, :, lat_slice, lon_slice]
+        for variable in params.pressure_variables
+    ]
+    fields += [
+        surface_fields.select_field(variable)[time_slice, lat_slice, lon_slice]
+        for variable in (params.sst_variable, params.t2m_variable)
+    ]
+
+    cf.write(fields, input_file)
+    print(f"  cut {N_TIME}x{2 * HALF_BOX}x{2 * HALF_BOX} window from real ERA5 data")
+
+
+def fetch_norm_stats(stats_file: str) -> None:
+    """Pull the real normalisation statistics from the reference repo."""
+    subprocess.run(["git", "fetch", "origin"], cwd=REFERENCE_REPO, check=True)
+    with open(stats_file, "wb") as handle:
+        subprocess.run(
+            ["git", "show", REFERENCE_STATS_REF],
+            cwd=REFERENCE_REPO,
+            stdout=handle,
+            check=True,
+        )
+    print(f"  fetched statistics from {REFERENCE_STATS_REF}")
+
+
+def test_real_data(work_dir: str) -> None:
+    """Run the real pipeline and check every step is structurally sound."""
+    print("\n" + "-" * 66)
+    print("real ERA5 data through preprocess -> detect -> stitch")
+    print("-" * 66)
+
+    input_file = f"{work_dir}/era5_window.nc"
+    stats_file = f"{work_dir}/normalisation_parameters.nc"
+    build_era5_input(input_file)
+    fetch_norm_stats(stats_file)
+
+    params = MLParameters(
+        input_file=input_file,
+        model_path=MODEL_PATH,
+        normalisation_stats_path=stats_file,
+    )
+    tracker = MLTracker(params)
+
+    # -- preprocess --------------------------------------------------------
+    tensor = tracker.preprocess()
+    n_lat, n_lon = len(tracker._lats), len(tracker._lons)
+    assert tuple(tensor.shape) == (N_CHANNELS, N_TIME, n_lat, n_lon), (
+        f"unexpected tensor shape {tuple(tensor.shape)}"
+    )
+    assert not np.isnan(tensor.numpy()).any(), "input tensor contains NaNs"
+    assert len(tracker._times) == N_TIME, "wrong number of timesteps read"
+    print(f"  preprocess(): {tuple(tensor.shape)}, no NaNs                    OK")
+
+    # -- detect ------------------------------------------------------------
+    tracker.detect()
+    expected = N_TIME * n_lat * n_lon
+    assert len(tracker._scores) == expected, (
+        f"expected {expected} scores, got {len(tracker._scores)}"
+    )
+    for score in tracker._scores[:100]:
+        assert set(score) == {"time", "lat", "lon", "probs"}, "unexpected score keys"
+        assert len(score["probs"]) == N_CLASSES, "expected 5 class probabilities"
+    sums = np.array([sum(s["probs"]) for s in tracker._scores])
+    assert np.abs(sums - 1.0).max() < 1e-4, "softmax outputs must sum to 1"
+    detected = sum(1 for s in tracker._scores if int(np.argmax(s["probs"])) != 0)
+    print(f"  detect():     {len(tracker._scores)} scores, softmax valid       OK")
+    print(f"                {detected} non-background pixels (not asserted on)")
+
+    # -- stitch ------------------------------------------------------------
+    trajectories = tracker.stitch()
+    assert isinstance(trajectories, list), "stitch() must return a list"
+    assert tracker.read_trajectories() == trajectories, (
+        "read_trajectories() must return what stitch() produced, else to_netcdf() "
+        "would write nothing"
+    )
+    for trajectory in trajectories:
+        assert trajectory.observations >= params.stitch_min_length
+        for key in ("time", "lat", "lon"):
+            assert key in trajectory.data, f"trajectory missing '{key}'"
+    print(f"  stitch():     {len(trajectories)} trajectories, all well-formed   OK")
+    if not trajectories:
+        print("                (none found - fine, model quality is not under test)")
+
+
+def main() -> None:
+    """Run the integration test against freshly prepared real data."""
+    print("=" * 66)
+    print("MLTracker pipeline integration test")
+    print("(checks the code works; does NOT judge model accuracy)")
+    print("=" * 66)
+
+    # Fresh temporary directory per run, removed on exit - nothing is cached,
+    # so the test can never pass against inputs left over from a previous run.
+    with tempfile.TemporaryDirectory(prefix="tctrack_ml_test_") as work_dir:
+        test_real_data(work_dir)
+
+    print("\n" + "=" * 66)
+    print("ALL CHECKS PASSED")
+    print("=" * 66)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_integration_ml_pipeline.py
+++ b/tests/integration/test_integration_ml_pipeline.py
@@ -171,13 +171,16 @@ def test_pipeline(input_file: str, stats_file: str) -> None:
 
 
 def test_output_writers(work_dir: str, input_file: str, stats_file: str) -> None:
-    """Check both writers produce readable CF-NetCDF files.
+    """Check run_tracker() and both writers produce readable CF-NetCDF files.
+
+    Drives the pipeline through run_tracker(), the public entry point, rather
+    than calling the steps by hand, so that is covered too.
 
     Uses a lowered threshold so that detections actually exist: at the default
     the model finds nothing in this small window, and the writers would take
     their empty-input path without the file-writing code ever running.
     """
-    section("output writers: detections_to_netcdf() and to_netcdf()")
+    section("run_tracker() and the output writers")
 
     tracker = make_tracker(
         input_file,
@@ -185,16 +188,20 @@ def test_output_writers(work_dir: str, input_file: str, stats_file: str) -> None
         threshold=LOW_THRESHOLD,
         stitch_min_length=1,  # keep single-timestep tracks, so tracks exist
     )
-    tracker.detect()
-    trajectories = tracker.stitch()
+
+    # run_tracker() runs detect() and stitch() and writes the trajectories.
+    tracks_file = f"{work_dir}/tracks.nc"
+    tracker.run_tracker(tracks_file)
+
+    trajectories = tracker.read_trajectories()
     assert tracker._candidates, (
         f"no detections even at threshold={LOW_THRESHOLD}, so the writers "
         "below cannot be exercised"
     )
-    assert trajectories, "no trajectories to write"
+    assert trajectories, "run_tracker() produced no trajectories"
     print(
-        f"  {len(tracker._candidates)} detections, "
-        f"{len(trajectories)} trajectories to write"
+        f"  run_tracker(): {len(tracker._candidates)} detections, "
+        f"{len(trajectories)} trajectories                OK"
     )
 
     # -- detections: CF point layout ---------------------------------------
@@ -224,9 +231,7 @@ def test_output_writers(work_dir: str, input_file: str, stats_file: str) -> None
     assert np.allclose(sst.array.tolist(), in_memory), "values changed on write/read"
     print(f"  detections_to_netcdf(): {len(fields)} variables, point layout    OK")
 
-    # -- trajectories: CF trajectory layout --------------------------------
-    tracks_file = f"{work_dir}/tracks.nc"
-    tracker.to_netcdf(tracks_file)
+    # -- trajectories: CF trajectory layout, written by run_tracker() ------
     track_fields = cf.read(tracks_file)
     assert track_fields, "trajectory file has no variables"
     assert track_fields[0].get_property("featureType") == "trajectory"

--- a/tests/integration/test_integration_ml_pipeline.py
+++ b/tests/integration/test_integration_ml_pipeline.py
@@ -43,6 +43,11 @@ TIME_START, N_TIME = 40, 2
 N_CHANNELS = 17
 N_CLASSES = 5
 
+# The default threshold of 0.5 finds nothing in this window - with five classes
+# a winning probability can be as low as ~0.21 - so the output writers are
+# exercised at a lower threshold, purely so that there is something to write.
+LOW_THRESHOLD = 0.2
+
 
 def build_era5_input(input_file: str) -> None:
     """Build the tracker's input file from the real ERA5 source files.
@@ -95,16 +100,11 @@ def fetch_norm_stats(stats_file: str) -> None:
     print(f"  fetched statistics from {REFERENCE_STATS_REF}")
 
 
-def test_real_data(work_dir: str) -> None:
+def test_real_data(input_file: str, stats_file: str) -> None:
     """Run the real pipeline and check every step is structurally sound."""
     print("\n" + "-" * 66)
     print("real ERA5 data through preprocess -> detect -> stitch")
     print("-" * 66)
-
-    input_file = f"{work_dir}/era5_window.nc"
-    stats_file = f"{work_dir}/normalisation_parameters.nc"
-    build_era5_input(input_file)
-    fetch_norm_stats(stats_file)
 
     params = MLParameters(
         input_file=input_file,
@@ -154,6 +154,73 @@ def test_real_data(work_dir: str) -> None:
         print("                (none found - fine, model quality is not under test)")
 
 
+def test_outputs(work_dir: str, input_file: str, stats_file: str) -> None:
+    """Check both output writers produce readable CF-NetCDF files.
+
+    Uses a lowered threshold so that detections actually exist: at the default
+    the model finds nothing in this small window, and the writers would take
+    their empty-input path without the file-writing code ever running.
+    """
+    print("\n" + "-" * 66)
+    print("output writers: detections_to_netcdf() and to_netcdf()")
+    print("-" * 66)
+
+    tracker = MLTracker(
+        MLParameters(
+            input_file=input_file,
+            model_path=MODEL_PATH,
+            normalisation_stats_path=stats_file,
+            threshold=LOW_THRESHOLD,
+            stitch_min_length=1,  # keep single-timestep tracks, so tracks exist
+        )
+    )
+    tracker.detect()
+    trajectories = tracker.stitch()
+    assert tracker._candidates, (
+        f"no detections even at threshold={LOW_THRESHOLD}; the writers below "
+        "cannot be exercised"
+    )
+    assert trajectories, "no trajectories to write"
+    print(f"  {len(tracker._candidates)} detections, {len(trajectories)} trajectories to write")
+
+    # -- detections: CF point layout ---------------------------------------
+    detections_file = f"{work_dir}/detections.nc"
+    tracker.detections_to_netcdf(detections_file)
+    fields = cf.read(detections_file)
+
+    written = {field.nc_get_variable("?"): field for field in fields}
+    assert len(written) == len(fields), "netCDF variable names collided"
+    for required in ("class_index", "score", "sea_surface_temperature"):
+        assert required in written, f"{required} missing from the detections file"
+    assert written["sea_surface_temperature"].get_property("standard_name") == (
+        "sea_surface_temperature"
+    ), "co-located variables should carry a CF standard name"
+    assert written["class_index"].get_property("flag_meanings"), (
+        "the categorical class should carry CF flag attributes"
+    )
+
+    example = next(iter(written.values()))
+    assert example.get_property("featureType") == "point", (
+        "detections are points, not trajectories"
+    )
+    for coordinate in ("time", "latitude", "longitude"):
+        assert example.coordinate(coordinate) is not None, f"missing {coordinate}"
+
+    # values should survive the round trip unchanged
+    from_file = written["sea_surface_temperature"].array.tolist()
+    in_memory = [c["sea_surface_temperature"] for c in tracker._candidates]
+    assert np.allclose(from_file, in_memory), "values changed on write/read"
+    print(f"  detections_to_netcdf(): {len(fields)} variables, point layout    OK")
+
+    # -- trajectories: CF trajectory layout --------------------------------
+    tracks_file = f"{work_dir}/tracks.nc"
+    tracker.to_netcdf(tracks_file)
+    track_fields = cf.read(tracks_file)
+    assert track_fields, "trajectory file has no variables"
+    assert track_fields[0].get_property("featureType") == "trajectory"
+    print(f"  to_netcdf():            {len(track_fields)} variables, trajectory layout OK")
+
+
 def main() -> None:
     """Run the integration test against freshly prepared real data."""
     print("=" * 66)
@@ -161,10 +228,15 @@ def main() -> None:
     print("(checks the code works; does NOT judge model accuracy)")
     print("=" * 66)
 
-    # Fresh temporary directory per run, removed on exit - nothing is cached,
-    # so the test can never pass against inputs left over from a previous run.
+    # Fresh temporary directory per run, removed on exit.
     with tempfile.TemporaryDirectory(prefix="tctrack_ml_test_") as work_dir:
-        test_real_data(work_dir)
+        input_file = f"{work_dir}/era5_window.nc"
+        stats_file = f"{work_dir}/normalisation_parameters.nc"
+        build_era5_input(input_file)
+        fetch_norm_stats(stats_file)
+
+        test_real_data(input_file, stats_file)
+        test_outputs(work_dir, input_file, stats_file)
 
     print("\n" + "=" * 66)
     print("ALL CHECKS PASSED")


### PR DESCRIPTION
Linked issue: #190

 The PR aims to build the core infrastructure for running ML models within the TCTrack framework. It uses exisiting base classes and defines new ml-specific classes.

It includes the following files (based on #204):

- [ ] `ml_tracker.py` : contains a base dataclass `TCMLParameters` to fetch ML Parameters and a base abstract class `TCMLTracker` that extends the existing Tracker by adding a load_model function (for ml models). These classes remain common for all ML models (basically it is a way to standardise processes for any incoming new model).
- [ ] `cyclone_track_ml.py` : inherits the base classes defined in `ml_tracker.py` and adds new model specific functions. Reads the model from hugging face hub repository and connects it to the run_tracker pipeline. For classes that are common for both ML and non-ML models like `TCTrackerMetadata` and `Trajectory` are inherited from the original `core/tracker.py`. 

- [ ] `test_ml_tracker.py` : unit, integration

Current update:

1. Inference: preprocess(), detect() where for each timestep an inference is run and points are classified under class 0 to 4 and this information is saved for each point. This process if repeated for each timestep.
2. Clustering:  cluestering_candidates() where clustering happens of neigbouring/adjacent points with same class. These clusters are called as candidates.
3. Merging nearby candidates
4. Check for nearest unmerged candidates
5.  Track stitching: stitch() where candidates that are of interest (based on a threshold) are linked together to form a TC track using above functions.

Assumptions:

merge_distance_deg = 2.0 (How close (in degrees) two candidates in the same timestep can be before the weaker one is discarded as a duplicate)
stitch_max_distance_deg = 3.0 (How far (in degrees) a candidate can be from a track's last known position and still be claimed as that same storm continuing)
stitch_max_gap: int = 1 (How many timesteps in a row a track can go unmatched before it's retired)
stitch_min_length: int = 2 (The minimum number of points a track must have to be kept in the final output)
