### PR TITLE
Pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+default_install_hook_types: [pre-commit]
+
+repos:
+
+  # Ruff linting / formatting
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.17
+    hooks:
+      - id: ruff-check
+        files: (src|tests)/.*\.py
+        args: [ --fix ]
+      - id: ruff-format
+        files: (src|tests)/.*\.py
+
+  # Mypy type checking
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.1.0
+    hooks:
+    -   id: mypy
+
+  # Docs formatting with blackdoc
+  - repo: https://github.com/keewis/blackdoc
+    rev: v0.4.2
+    hooks:
+    - id: blackdoc
+      files: docs/
+      additional_dependencies: ["black==25.9.0"]

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ pull request.
 Additional dependencies for development can be installed as follows:
 ```sh
 pip install --editable .[dev]
+pre-commit install
 ```
 
 Full details for contribution and developers can be found in the

--- a/docs/developer/guidelines.rst
+++ b/docs/developer/guidelines.rst
@@ -167,11 +167,14 @@ Thus, good style is a requirement for submitting code to *TCTrack*.
 - `mypy <http://mypy-lang.org/>`_ for static type checking of
   `type hints <https://docs.python.org/3/library/typing.html>`_.
 
-These will be checked on all pull requests and commits to main, so it is suggested you
-run them on your code before committing.
+These will be checked on all pull requests and commits to main, but it is suggested that you install the ``pre-commit`` hooks so that any changes will be checked each time you commit:
 
-This can be done with a development install by running the following bash commands from
-the root directory:
+.. code-block:: shell
+
+    pre-commit install
+
+To manually run the checks instead, run the following bash commands from the root
+directory with a development installation:
 
 .. code-block:: shell
 

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -67,9 +67,10 @@ pip can then be run to install the code from the source into the environment::
     pip install .
 
 If you are developing TCTrack you should install as an editable package with the
-additional developer dependencies::
+additional developer dependencies and the pre-commit hooks installed::
 
     pip install --editable .[dev]
+    pre-commit install
 
 The `dev` optional dependencies include the `test`, `lint`, and `doc` subgroups.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ test = [
 ]
 lint = [
     "ruff",
-    "blackdoc<=0.4.2",
-    "black<=25.1.0",  # Pin version due to blackdoc incompatibility. Remove once resolved
+    "blackdoc>=0.4.2", # Pin versions for black-blackdoc compatibilty.
+    "black>=25.9.0",   # See https://blackdoc.readthedocs.io/en/latest/changelog.html
     "mypy",
     "pytest",
     "xarray",
@@ -58,8 +58,6 @@ doc = [
     "sphinx<8.2.0",  # Pin version due to autodoc type hints incompatibilities
     "sphinx_rtd_theme",
     "sphinx_autodoc_typehints",
-    "blackdoc<=0.4.2",
-    "black<=25.1.0",  # Pin version due to blackdoc incompatibility. Remove once resolved
 ]
 dev = [
     "tctrack[test,lint,doc]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ doc = [
 ]
 dev = [
     "tctrack[test,lint,doc]",
+    "pre-commit",
 ]
 
 [project.urls]


### PR DESCRIPTION
This adds pre-commit hooks for the ruff, mypy, and blackdoc checks that are used in CI.

It adds pre-commit to the developer dependencies and adds instructions for installing the hooks when doing a development install.

It also updates the black and blackdoc versions to newer versions that resolve the previous incompatibility issue.