### PR TITLE
TSTORMS gfortran install

### DIFF
--- a/docs/tracking-algorithms/tstorms.rst
+++ b/docs/tracking-algorithms/tstorms.rst
@@ -32,23 +32,22 @@ number of fixes for hard-coded filepaths etc. over the original to aid usability
 
 TSTORMS comprises two codes, one for storm detection (``tstorms_driver``) and another
 for generating trajectories (``trajectory_analysis``).
-The code is built using Make and requires a Fortran compiler (ifort default recommended)
-and an installation of NetCDF.
+The code is built using Make and requires a Fortran compiler and an installation of
+NetCDF.
 The steps are summarised here::
 
     git clone https://github.com/Cambridge-ICCS/TSTORMS.git
     cd TSTORMS/
     cd tstorms_driver/
-    make
+    make FC=gfortran
     cd ../trajectory_analysis/
-    make
+    make FC=gfortran
 
 This will clone the TSTORMS code and then then build the two TSTORMS executables using
 Make.
-Using a different compiler requires modification to both
-``tstorms_driver/mkmf_template`` and ``trajectory_analysis/mkmf_template``
-to set ``FC``, ``LD``, and any associated flags appropriately.
-This will be required if building with gfortran or Intel oneAPI compilers >= 2025 (ifx).
+``ifort`` or ``ifx`` can also be used for the compilation. Any other compilers will
+require modification to both ``tstorms_driver/mkmf_template`` and
+``trajectory_analysis/mkmf_template``.
 
 Once this is complete the TSTORMS executables can then be found at
 ``/path/to/TSTORMS_installation/tstorms_driver/tstorms_driver.exe`` and

--- a/tutorial/install_tstorms.sh
+++ b/tutorial/install_tstorms.sh
@@ -11,9 +11,9 @@ cd TSTORMS/
 
 # Build using Make
 cd tstorms_driver/
-make
+make FC=gfortran
 cd ../trajectory_analysis/
-make
+make FC=gfortran
 
 # return to tutorial directory
 cd ../../


### PR DESCRIPTION
This uses the update to TSTORMS (Cambridge-ICCS/TSTORMS#2) to use gfortran instead of ifort. Closes #206 

The issue with TSTORMS in the tutorial will also be resolved. Closes #156 
This is not specifically fixed here. Instead it relies on the updates to the calendar in TSTORMS (Cambridge-ICCS/TSTORMS#3) and the bug fix to cf.curl_xy in #205.