### PR TITLE
Move input files to an argument of `run_tracker`

### DIFF
--- a/docs/tracking-algorithms/tempest_extremes.rst
+++ b/docs/tracking-algorithms/tempest_extremes.rst
@@ -108,7 +108,6 @@ with :meth:`~TETracker.stitch`:
     ]
 
     dn_params = te.TEDetectParameters(
-        in_data=input_files,
         search_by_min="psl",
         time_filter="6hr",
         merge_dist=6.0,
@@ -119,6 +118,7 @@ with :meth:`~TETracker.stitch`:
     )
 
     te_tracker = te.TETracker(dn_params)
+    te_tracker.set_input_files(input_files)
 
     run_info = te_tracker.detect()
 
@@ -185,7 +185,7 @@ appropriate :class:`TEDetectParameters` and :class:`TEStitchParameters`:
     sn_params = te.TEStitchParameters(...)
     te_tracker = te.TETracker(dn_params, sn_params)
 
-    te_tracker.run_tracker("my_cf_tracks.nc")
+    te_tracker.run_tracker(input_files, "my_cf_tracks.nc")
 
 When running in this way there are certain parameters that *should not* be set. In
 :class:`TEStitchParameters`, :attr:`~TEStitchParameters.in_fmt` and

--- a/docs/tracking-algorithms/track.rst
+++ b/docs/tracking-algorithms/track.rst
@@ -107,12 +107,11 @@ names for the windspeed should be specified with
 
     params = TRACKParameters(
         base_dir="/path/to/track",
-        input_file="ua_va_file_F256.nc",
         wind_var_names=("ua", "va"),
     )
 
     tracker = TRACKTracker(params)
-    tracker.run_tracker("trajectories.nc")
+    tracker.run_tracker("ua_va_file_F256.nc", "trajectories.nc")
 
 In addition to :attr:`~TRACKParameters.base_dir` and
 :attr:`~TRACKParameters.wind_var_names` there are a number of other parameters

--- a/docs/tracking-algorithms/tstorms.rst
+++ b/docs/tracking-algorithms/tstorms.rst
@@ -75,10 +75,9 @@ Detection
 ^^^^^^^^^
 
 In the following example we demonstrate the approach for detecting tropical cyclones
-using TSTORMS. First, we set up the :meth:`~TSTORMSTracker.detect`
-functionality to run on a series of input files to generate output.
-Detection of candidate storms is based on locating points that satisfy certain minima or
-maxima, with full details of each input given in the :class:`TSTORMSDetectParameters`
+using TSTORMS. First, we set up the :meth:`~TSTORMSTracker.detect` functionality to
+detect candidate storms based on locating points that satisfy certain minima or maxima,
+with full details of each input given in the :class:`TSTORMSDetectParameters`
 documentation:
 
 .. code-block:: python
@@ -89,17 +88,19 @@ documentation:
         TSTORMSTracker,
     )
 
+    input_files = [
+        "path/to/u_input.nc",
+        "path/to/v_input.nc",
+        "path/to/vort_input.nc",
+        "path/to/tm_input.nc",
+        "path/to/slp_input.nc",
+    ]
+
     tstorms_params = TSTORMSBaseParameters(
         tstorms_dir="path/to/tstorms/installation/",
         output_dir="path/to/place/outputs/",
-        input_dir="path/to/input/files/",
     )
     detect_params = TSTORMSDetectParameters(
-        u_in_file="u_input.nc",
-        v_in_file="v_input.nc",
-        vort_in_file="vort_input.nc",
-        tm_in_file="tm_input.nc",
-        slp_in_file="slp_input.nc",
         vort_crit=3.5e-5,
         tm_crit=0.0,
         thick_crit=50.0,
@@ -113,6 +114,7 @@ documentation:
 
     # Initialize the tracker
     tracker = TSTORMSTracker(tstorms_params, detect_params)
+    tracker.set_input_files(input_files)
 
     detect_call = tracker.detect(verbosity=2)
 
@@ -196,12 +198,13 @@ object with appropriate :class:`TSTORMSDetectParameters` and :class:`TSTORMSStit
         TSTORMSTracker,
     )
 
+    input_files = [...]
     tstorms_params = TSTORMSBaseParameters(...)
     detect_params = TSTORMSDetectParameters(...)
     stitch_params = TSTORMSStitchParameters(...)
     tracker = TSTORMSTracker(tstorms_params, detect_params, stitch_params)
 
-    tracker.run_tracker("my_tstorms_cf_trajectories.nc")
+    tracker.run_tracker(input_files, "my_tstorms_cf_trajectories.nc")
 
 Input data
 ----------
@@ -221,7 +224,6 @@ variable names described below.
     :attr:`~TSTORMSDetectParameters.use_sfc_wind` to ``False``.
   * Named ``u_ref`` or ``u850`` in the NetCDF file depending on the value of
     :attr:`~TSTORMSDetectParameters.use_sfc_wind`.
-  * The filename is proviuded to TSTORMS through :attr:`~TSTORMSDetectParameters.u_in_file`.
 
 * Northward Velocity:
 
@@ -231,27 +233,23 @@ variable names described below.
     :attr:`~TSTORMSDetectParameters.use_sfc_wind` to ``False``.
   * Named ``v_ref`` or ``v850`` in the NetCDF file depending on the value of
     :attr:`~TSTORMSDetectParameters.use_sfc_wind`.
-  * The filename is proviuded to TSTORMS through :attr:`~TSTORMSDetectParameters.v_in_file`.
 
 * Vorticity:
 
   * Vorticity in s-1.
   * Should be at a pressure level of 850 hPa.
   * Named ``vort850`` in the NetCDF file.
-  * The filename is proviuded to TSTORMS through :attr:`~TSTORMSDetectParameters.vort_in_file`.
 
 * Mean Temperature:
 
   * Mean air temperature in the warm core layer in degrees K.
   * Should be the mean air temperature over 500-200 hPa.
   * Named ``tm`` in the NetCDF file.
-  * The filename is proviuded to TSTORMS through :attr:`~TSTORMSDetectParameters.tm_in_file`.
 
 * Sea-level Pressure:
 
   * Sea-level pressure in Pa .
   * Named ``slp`` in the NetCDF file.
-  * The filename is proviuded to TSTORMS through :attr:`~TSTORMSDetectParameters.slp_in_file`.
 
 To extract these variables from an input dataset and write to individual files with the
 requisite variable names, combine multiple files over times, or regrid variables to a

--- a/src/tctrack/core/tracker.py
+++ b/src/tctrack/core/tracker.py
@@ -9,7 +9,8 @@ from abc import ABC, abstractmethod
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import asdict, dataclass, fields
 from datetime import timedelta
-from typing import IO, TypedDict, Union
+from pathlib import Path
+from typing import IO, Iterable, TypedDict, Union
 
 import cf
 from cftime import date2num, datetime
@@ -126,12 +127,15 @@ class TCTracker(ABC):
         A dictionary containing global metadata about the data and TCTrack parameters.
         This will be populated by the base class, but additional subclass-specific
         metadata can be added using the :meth:`_set_metadata` method.
+    _input_files : list[str]
+        A list of file paths of NetCDF input files.
     """
 
     # Private attributes
     _variable_metadata: dict[str, TCTrackerMetadata] | None = None
     _time_metadata: TCTrackerTimeMetadata | None = None
     _global_metadata: dict[str, str]
+    _input_files: list[str]
 
     @property
     @abstractmethod
@@ -192,6 +196,23 @@ class TCTracker(ABC):
             err_msg = "_global_metadata has not been initialized."
             raise AttributeError(err_msg)
         return self._global_metadata
+
+    def set_input_files(self, input_files: str | Iterable[str]):
+        """Store the input file(s) as a list in a class attribute."""
+        if isinstance(input_files, str):
+            self._input_files = [input_files]
+        elif isinstance(input_files, Iterable) and all(
+            isinstance(f, str) for f in input_files
+        ):
+            self._input_files = list(input_files)
+        else:
+            msg = "input_files must be a str or an iterable of str"
+            raise TypeError(msg)
+
+        for file in self._input_files:
+            if not Path(file).exists():
+                msg = f"Input file does not exist ({file})."
+                raise FileNotFoundError(msg)
 
     @abstractmethod
     def _set_metadata(self) -> None:
@@ -674,7 +695,7 @@ class TCTracker(ABC):
         cf.write(fields, output_file)  # type: ignore[operator]
 
     @abstractmethod
-    def run_tracker(self, output_file: str) -> None:
+    def run_tracker(self, input_files: str | Iterable[str], output_file: str) -> None:
         """
         Run the tracker to obtain tropical cyclone track trajectories as NetCDF file.
 
@@ -687,6 +708,8 @@ class TCTracker(ABC):
 
         Arguments
         ---------
+        input_files : str | Iterable[str]
+            A (list of) file path(s) containing NetCDF input data to use in the tracker.
         output_file : str
             Filename to which the tropical cyclone trajectories are saved.
         """

--- a/src/tctrack/tempest_extremes/tempest_extremes.py
+++ b/src/tctrack/tempest_extremes/tempest_extremes.py
@@ -200,9 +200,6 @@ class TEDetectParameters(TCTrackerParameters):
     and the `DetectNodes Source <https://github.com/ClimateGlobalChange/tempestextremes/blob/master/src/nodes/DetectNodes.cpp>`_
     """
 
-    in_data: list[str]
-    """List of strings of NetCDF input files."""
-
     out_header: bool = False
     """Include header at the top of the output file?"""
 
@@ -430,7 +427,7 @@ class TETracker(TCTracker):
 
     def __init__(
         self,
-        detect_parameters: TEDetectParameters,
+        detect_parameters: TEDetectParameters | None = None,
         stitch_parameters: TEStitchParameters | None = None,
     ):
         """
@@ -444,7 +441,10 @@ class TETracker(TCTracker):
             Class containing the parameters for the stitching step
             Defaults to the default values in TEStitchParameters Class
         """
-        self.detect_parameters: TEDetectParameters = detect_parameters
+        if detect_parameters is not None:
+            self.detect_parameters: TEDetectParameters = detect_parameters
+        else:
+            self.detect_parameters = TEDetectParameters()
 
         if stitch_parameters is not None:
             self.stitch_parameters: TEStitchParameters = stitch_parameters
@@ -488,13 +488,7 @@ class TETracker(TCTracker):
         """
         dn_argslist = ["DetectNodes"]
 
-        if self.detect_parameters.in_data is not None:
-            dn_argslist.extend(
-                [
-                    "--in_data",
-                    ";".join(self.detect_parameters.in_data),
-                ]
-            )
+        dn_argslist.extend(["--in_data", ";".join(self._input_files)])
         out_file = str(
             Path(self.detect_parameters.output_dir) / self.detect_parameters.output_file
         )
@@ -589,7 +583,7 @@ class TETracker(TCTracker):
 
         return dn_argslist
 
-    def detect(self, input_files: str | Iterable[str]):
+    def detect(self):
         """
         Call the DetectNodes utility of Tempest Extremes.
 
@@ -617,11 +611,6 @@ class TETracker(TCTracker):
         - ``var1``, ``var2``, etc., are scalar variables as defined by
           :attr:`~TEDetectParameters.output_commands` (typically, psl, orog).
 
-        Arguments
-        ---------
-        input_files : str | Iterable[str]
-            A (list of) file path(s) containing NetCDF input data to use in the tracker.
-
         Returns
         -------
         dict
@@ -646,9 +635,9 @@ class TETracker(TCTracker):
 
         >>> my_params = TEDetectParameters(...)
         >>> my_tracker = TETracker(detect_parameters=my_params)
-        >>> result = my_tracker.detect("input.nc")
+        >>> my_tracker.set_input_files("input.nc")
+        >>> result = my_tracker.detect()
         """
-        self.set_input_files(input_files)
         Path(self.detect_parameters.output_dir).mkdir(parents=True, exist_ok=True)
         dn_call_list = self._make_detect_nodes_call()
         return self.run_tracker_subprocess("DetectNodes", dn_call_list)
@@ -940,8 +929,8 @@ class TETracker(TCTracker):
         """Set the time and variable metadata attributes by reading from input files.
 
         Reads metadata for each variable listed in
-        :attr:`detect_parameters.output_commands` from the input NetCDF files
-        defined in :attr:`detect_parameters.in_data` (matching the NetCDF variable
+        :attr:`detect_parameters.output_commands` from the input NetCDF files that are
+        set by :meth:`set_input_files` (matching the NetCDF variable
         name). These will be stored in the :attr:`variable_metadata` attribute as a
         dictionary of :class:`TCTrackerMetadata` objects. This will be called from the
         :meth:`set_metadata` method.
@@ -956,10 +945,10 @@ class TETracker(TCTracker):
         To read in the metadata for ``psl`` from ``inputs.nc``:
 
         >>> detect_params = TEDetectParameters(
-        >>>     in_data=["inputs.nc"],
         >>>     output_commands=[TEOutputCommand(var="psl", operator="min", dist=0)],
         >>> )
         >>> tracker = TETracker(detect_params, stitch_params)
+        >>> tracker.set_input_files("inputs.nc")
         >>> tracker.set_metadata()
         >>> tracker.variable_metadata
         {
@@ -973,8 +962,6 @@ class TETracker(TCTracker):
             ),
         }
         """
-        input_files = self.detect_parameters.in_data
-
         # set time metadata
         variable_name = (
             self.detect_parameters.search_by_min
@@ -982,7 +969,7 @@ class TETracker(TCTracker):
             or "PSL"
         )
         fields = cf.read(
-            input_files,
+            self._input_files,
             select=f"ncvar%{variable_name}",  # type: ignore[operator]
             netcdf_backend="netCDF4",
         )
@@ -1011,7 +998,7 @@ class TETracker(TCTracker):
 
         # Set the variable metadata for the output variables
         var_outputs = self.detect_parameters.output_commands
-        if var_outputs is None or input_files is None:
+        if var_outputs is None:
             return
 
         for var_output in var_outputs:
@@ -1019,7 +1006,7 @@ class TETracker(TCTracker):
 
             # Get the variable field from the netcdf file
             fields = cf.read(
-                input_files,
+                self._input_files,
                 select=f"ncvar%{var_name}",  # type: ignore[operator]
                 netcdf_backend="netCDF4",
             )
@@ -1085,6 +1072,7 @@ class TETracker(TCTracker):
         >>> my_tracker = TETracker(detect_params, stitch_params)
         >>> my_tracker.run_tracker("input.nc", "output.nc")
         """
-        self.detect(input_files)
+        self.set_input_files(input_files)
+        self.detect()
         self.stitch()
         self.to_netcdf(output_file)

--- a/src/tctrack/tempest_extremes/tempest_extremes.py
+++ b/src/tctrack/tempest_extremes/tempest_extremes.py
@@ -11,7 +11,7 @@ import csv
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypedDict
+from typing import Iterable, TypedDict
 
 import cf
 
@@ -589,7 +589,7 @@ class TETracker(TCTracker):
 
         return dn_argslist
 
-    def detect(self):
+    def detect(self, input_files: str | Iterable[str]):
         """
         Call the DetectNodes utility of Tempest Extremes.
 
@@ -617,6 +617,11 @@ class TETracker(TCTracker):
         - ``var1``, ``var2``, etc., are scalar variables as defined by
           :attr:`~TEDetectParameters.output_commands` (typically, psl, orog).
 
+        Arguments
+        ---------
+        input_files : str | Iterable[str]
+            A (list of) file path(s) containing NetCDF input data to use in the tracker.
+
         Returns
         -------
         dict
@@ -641,8 +646,9 @@ class TETracker(TCTracker):
 
         >>> my_params = TEDetectParameters(...)
         >>> my_tracker = TETracker(detect_parameters=my_params)
-        >>> result = my_tracker.detect()
+        >>> result = my_tracker.detect("input.nc")
         """
+        self.set_input_files(input_files)
         Path(self.detect_parameters.output_dir).mkdir(parents=True, exist_ok=True)
         dn_call_list = self._make_detect_nodes_call()
         return self.run_tracker_subprocess("DetectNodes", dn_call_list)
@@ -1047,7 +1053,7 @@ class TETracker(TCTracker):
                     cell_method = cf.CellMethod("area", method, qualifiers=qualifier)
                 self._variable_metadata[var_name].constructs = [cell_method]
 
-    def run_tracker(self, output_file: str):
+    def run_tracker(self, input_files: str | Iterable[str], output_file: str):
         """Run TempestExtremes tracker to obtain tropical cyclone track trajectories.
 
         This first runs :meth:`detect` to get TC candidates at each time. Then
@@ -1056,6 +1062,8 @@ class TETracker(TCTracker):
 
         Arguments
         ---------
+        input_files : str | Iterable[str]
+            A (list of) file path(s) containing NetCDF input data to use in the tracker.
         output_file : str
             Filename to which the tropical cyclone trajectories are saved.
 
@@ -1075,8 +1083,8 @@ class TETracker(TCTracker):
         >>> detect_params = TEDetectParameters(...)
         >>> stitch_params = TEStitchParameters(...)
         >>> my_tracker = TETracker(detect_params, stitch_params)
-        >>> my_tracker.run_tracker()
+        >>> my_tracker.run_tracker("input.nc", "output.nc")
         """
-        self.detect()
+        self.detect(input_files)
         self.stitch()
         self.to_netcdf(output_file)

--- a/src/tctrack/track/track.py
+++ b/src/tctrack/track/track.py
@@ -32,12 +32,6 @@ class TRACKParameters(TCTrackerParameters):
     base_dir: str
     """The filepath to the directory where TRACK is installed."""
 
-    input_file: str
-    """
-    NetCDF input file containing the north and easterly wind speeds on a Gaussian grid
-    in m/s.
-    """
-
     filter_distance: float | None = None
     """The minimum start-to-end distance which trajectories must travel, in degrees."""
 
@@ -114,11 +108,6 @@ class TRACKTracker(TCTracker):
         self.parameters: TRACKParameters = parameters
 
         # Get sizes from input file
-        input_file = self.parameters.input_file
-        if not Path(input_file).exists():
-            msg = f"Input file does not exist ({input_file})."
-            raise FileNotFoundError(msg)
-        self._ny, self._nx = lat_lon_sizes(input_file)
 
         # Set up files in the TRACK directory (if not already)
         base_dir = self.parameters.base_dir
@@ -129,6 +118,16 @@ class TRACKTracker(TCTracker):
     def _parameters(self) -> list[TCTrackerParameters]:
         """A list of the parameter objects that is accessible from the base class."""
         return [self.parameters]
+
+    def set_input_files(self, input_files: str | Iterable[str]):
+        """Check the input file and store it as a class attribute."""
+        super().set_input_files(input_files)
+
+        if len(self._input_files) > 1:
+            msg = "TRACK only accepts one input file, but multiple have been provided."
+            raise ValueError(msg)
+
+        self._ny, self._nx = lat_lon_sizes(self._input_files[0])
 
     def _get_initialisation_inputs(self, inputs: list[str]):
         """Add "initialisation" inputs common to both tracking and filter_tracks calls.
@@ -496,9 +495,10 @@ class TRACKTracker(TCTracker):
         """Use TRACK to calculate the vorticity from the wind components.
 
         This method requires the wind speed components to be on a Gaussian grid in a
-        netcdf file, given by :attr:`~TRACKParameters.input_file`. This is copied to the
-        TRACK 'indat' folder and used as an input for a system call to TRACK to
-        calculate the vorticity.
+        netcdf file, and for this to have been provided to :meth:`set_input_files`.
+
+        The input file will be copied to the TRACK 'indat' folder and used as an input
+        for a system call to TRACK to calculate the vorticity.
 
         The vorticity is written to a new file in the 'indat' folder given by
         :attr:`~TRACKParameters.vorticity_file`. This uses the following layout::
@@ -521,11 +521,11 @@ class TRACKTracker(TCTracker):
         """
         params = self.parameters
         # Copy the input file to TRACK
-        shutil.copy(params.input_file, params.base_dir + "/indat/")
-        input_filename = Path(params.input_file).name
+        input_file = self._input_files[0]
+        shutil.copy(input_file, params.base_dir + "/indat/")
         # Run TRACK to perform the calculation
         inputs = self._get_calculate_vorticity_inputs()
-        self._run_track_process("calculate_vorticity", input_filename, inputs)
+        self._run_track_process("calculate_vorticity", input_file, inputs)
 
     def spectral_filtering(self):
         """Use TRACK to perform the spectral filtering of the vorticity.
@@ -605,7 +605,7 @@ class TRACKTracker(TCTracker):
 
         This reads the output file from the filter_trajectories step, i.e.
         ``ff_trs.<ext>.nc`` in the TRACK 'outdat' folder. It also takes the times from
-        the data in :attr:`TRACKParameters.input_file`.
+        the data in the input file.
 
         Returns
         -------
@@ -642,7 +642,7 @@ class TRACKTracker(TCTracker):
         intensity = fields.select_field("ncvar%intensity").array
 
         # Convert the time indicies to datetimes using the input file data
-        all_times = cf.read(params.input_file)[0].coordinate("time")  # type: ignore[operator]
+        all_times = cf.read(self._input_files)[0].coordinate("time")  # type: ignore[operator]
         datetimes = all_times.datetime_array[time_idx]
 
         trajectories: list[Trajectory] = []
@@ -668,7 +668,7 @@ class TRACKTracker(TCTracker):
         ValueError
             If a variable with time coordinate is not found in the input file.
         """
-        vars_with_time = cf.read(self.parameters.input_file).select_by_construct("time")  # type: ignore[operator]  # type: ignore[operator]
+        vars_with_time = cf.read(self._input_files).select_by_construct("time")  # type: ignore[operator]  # type: ignore[operator]
         if len(vars_with_time) == 0:
             msg = r"No variable with 'time' coordinate found in TRACK input file."
             raise ValueError(msg)
@@ -723,7 +723,8 @@ class TRACKTracker(TCTracker):
         Arguments
         ---------
         input_files : str | Iterable[str]
-            A (list of) file path(s) containing NetCDF input data to use in the tracker.
+            A file path for the NetCDF input file containing the north and easterly wind
+            speeds on a Gaussian grid in m/s.
         output_file : str
             Filename to which the tropical cyclone track trajectories are saved.
 

--- a/src/tctrack/track/track.py
+++ b/src/tctrack/track/track.py
@@ -12,6 +12,7 @@ import shutil
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Iterable
 
 import cf
 
@@ -701,7 +702,7 @@ class TRACKTracker(TCTracker):
             construct_kwargs=[{"key": "plev"}, {"axes": "plev"}],
         )
 
-    def run_tracker(self, output_file: str):
+    def run_tracker(self, input_files: str | Iterable[str], output_file: str):
         """Run the TRACK tracker to obtain the tropical cyclone track trajectories.
 
         This runs the relevant methods in order:
@@ -720,6 +721,8 @@ class TRACKTracker(TCTracker):
 
         Arguments
         ---------
+        input_files : str | Iterable[str]
+            A (list of) file path(s) containing NetCDF input data to use in the tracker.
         output_file : str
             Filename to which the tropical cyclone track trajectories are saved.
 
@@ -737,8 +740,10 @@ class TRACKTracker(TCTracker):
 
         >>> track_params = TRACKParameters(...)
         >>> my_tracker = TRACKTracker(track_params)
-        >>> my_tracker.run_tracker("trajectories.nc")
+        >>> my_tracker.run_tracker("ua_va_inputs.nc", "trajectories.nc")
         """
+        self.set_input_files(input_files)
+
         self.calculate_vorticity()
         self.spectral_filtering()
         self.tracking()

--- a/src/tctrack/track/track.py
+++ b/src/tctrack/track/track.py
@@ -673,11 +673,12 @@ class TRACKTracker(TCTracker):
             msg = r"No variable with 'time' coordinate found in TRACK input file."
             raise ValueError(msg)
         time_coord = vars_with_time[0].coordinate("time")
+        time_array = time_coord.datetime_array
         self._time_metadata = {
             "calendar": time_coord.calendar,
             "units": time_coord.units,
-            "start_time": time_coord.data[0],
-            "end_time": time_coord.data[-1],
+            "start_time": time_array[0],
+            "end_time": time_array[-1],
         }
 
         self._variable_metadata = {}

--- a/src/tctrack/tstorms/tstorms.py
+++ b/src/tctrack/tstorms/tstorms.py
@@ -10,6 +10,7 @@ import tempfile
 import textwrap
 import warnings
 from dataclasses import dataclass
+from typing import Iterable
 
 import cf
 from cftime import num2date
@@ -938,7 +939,7 @@ class TSTORMSTracker(TCTracker):
         time = list(map(int, line[-4:]))
         return time, return_vars
 
-    def run_tracker(self, output_file: str):
+    def run_tracker(self, input_files: str | Iterable[str], output_file: str):
         """Run TSTORMS tracker to obtain tropical cyclone track trajectories.
 
         This first runs :meth:`detect` to get TC candidates at each time. Then
@@ -947,6 +948,8 @@ class TSTORMSTracker(TCTracker):
 
         Arguments
         ---------
+        input_files : str | Iterable[str]
+            A (list of) file path(s) containing NetCDF input data to use in the tracker.
         output_file : str
             Filename to which the tropical cyclone trajectories are saved.
 
@@ -962,12 +965,14 @@ class TSTORMSTracker(TCTracker):
         To set the parameters, instantiate a :class:`TSTORMSTracker` instance and run
         `run_tracker()`:
 
+        >>> input_files = [...]
         >>> tstorms_params = TSTORMSBaseParameters(...)
         >>> detect_params = TSTORMSDetectParameters(...)
         >>> stitch_params = TSTORMSStitchParameters(...)
         >>> my_tracker = TSTORMSTracker(tstorms_params, detect_params, stitch_params)
-        >>> my_tracker.run_tracker()
+        >>> my_tracker.run_tracker(input_files, "trajectories.nc")
         """
+        self.set_input_files(input_files)
         self.detect()
         self.stitch()
         self.to_netcdf(output_file)

--- a/src/tctrack/tstorms/tstorms.py
+++ b/src/tctrack/tstorms/tstorms.py
@@ -65,49 +65,54 @@ class TSTORMSDetectParameters(TCTrackerParameters):
         - If do_thickness is set to True as this has no effect.
     """
 
-    u_in_file: str
+    u_in_file: str | None = None
     """
     Filename of the u (zonal) velocity input file.
     This should be a NetCDF file containing a single lat-lon slice of the u field named
     ``u_ref`` (if :attr:`use_sfc_wind` is ``True``) or ``u850``.
     This should be the full path unless the location of input files was specified in
     :class:`TSTORMSBaseParameters`' ``input_dir``.
+    If unset, it will be automatically determined from the input file list.
     """
 
-    v_in_file: str
+    v_in_file: str | None = None
     """
     Filename of the v (meridional) velocity input file.
     This should be a NetCDF file containing a single lat-lon slice of the v field named
     ``v_ref`` (if :attr:`use_sfc_wind` is ``True``) or ``v850``.
     This should be the full path unless the location of input files was specified in
     :class:`TSTORMSBaseParameters`' ``input_dir``.
+    If unset, it will be automatically determined from the input file list.
     """
 
-    vort_in_file: str
+    vort_in_file: str | None = None
     """
     Filename of the vorticity input file.
     This should be a NetCDF file containing a single lat-lon slice of the vorticity
     field named ``vort850`` at the 850 hPa level.
     This should be the full path unless the location of input files was specified in
     :class:`TSTORMSBaseParameters`' ``input_dir``.
+    If unset, it will be automatically determined from the input file list.
     """
 
-    tm_in_file: str
+    tm_in_file: str | None = None
     """
     Filename of the temperature input file.
     This should be a NetCDF file containing a single lat-lon slice of the mean
     temperature of the warm-core layer named ``tm``.
     This should be the full path unless the location of input files was specified in
     :class:`TSTORMSBaseParameters`' ``input_dir``.
+    If unset, it will be automatically determined from the input file list.
     """
 
-    slp_in_file: str
+    slp_in_file: str | None = None
     """
     Filename of the sea-level pressure input file.
     This should be a NetCDF file containing a single lat-lon slice of sea-level pressure
     named ``slp``.
     This should be the full path unless the location of input files was specified in
     :class:`TSTORMSBaseParameters`' ``input_dir``.
+    If unset, it will be automatically determined from the input file list.
     """
 
     use_sfc_wind: bool = True
@@ -263,11 +268,16 @@ class TSTORMSTracker(TCTracker):
 
     # Private attributes
     _tempdir: tempfile.TemporaryDirectory
+    _u_in_file: str | None = None
+    _v_in_file: str | None = None
+    _vort_in_file: str | None = None
+    _tm_in_file: str | None = None
+    _slp_in_file: str | None = None
 
     def __init__(
         self,
         tstorms_parameters: TSTORMSBaseParameters,
-        detect_parameters: TSTORMSDetectParameters,
+        detect_parameters: TSTORMSDetectParameters | None = None,
         stitch_parameters: TSTORMSStitchParameters | None = None,
     ):
         """
@@ -277,20 +287,35 @@ class TSTORMSTracker(TCTracker):
         ----------
         tstorms_parameters : TSTORMSBaseParameters
             Class containing the parameters for setting up TSTORMS usage.
-        detect_parameters : TSTORMSDetectParameters
+        detect_parameters : TSTORMSDetectParameters | None
             Class containing the parameters for the node detection in TSTORMS.
             Used to create the namelists for `tstorms_driver`.
+            Defaults to the default values in TSTORMSDetectParameters Class
         stitch_parameters : TSTORMSStitchParameters | None
             Class containing the parameters for the stitching algorithm of TSTORMS
             Defaults to the default values in TSTORMSStitchParameters Class
         """
         self.tstorms_parameters: TSTORMSBaseParameters = tstorms_parameters
-        self.detect_parameters: TSTORMSDetectParameters = detect_parameters
+
+        if detect_parameters is not None:
+            self.detect_parameters: TSTORMSDetectParameters = detect_parameters
+        else:
+            self.detect_parameters = TSTORMSDetectParameters()
 
         if stitch_parameters is not None:
             self.stitch_parameters: TSTORMSStitchParameters = stitch_parameters
         else:
             self.stitch_parameters = TSTORMSStitchParameters()
+
+        # Set any manually defined input file attributes
+        for var in ["u", "v", "vort", "tm", "slp"]:
+            file_param = getattr(self.detect_parameters, f"{var}_in_file")
+            if file_param is not None:
+                setattr(
+                    self,
+                    f"_{var}_in_file",
+                    os.path.join(self.tstorms_parameters.input_dir, file_param),
+                )
 
         # Ensure the output directory exists, create if not.
         output_dir = self.tstorms_parameters.output_dir
@@ -300,6 +325,50 @@ class TSTORMSTracker(TCTracker):
     def _parameters(self) -> list[TCTrackerParameters]:
         """A list of the parameter objects that is accessible from the base class."""
         return [self.tstorms_parameters, self.detect_parameters, self.stitch_parameters]
+
+    def set_input_files(self, input_files: str | Iterable[str]):
+        """Check the input files and set the appropriate input file parameters."""
+        super().set_input_files(input_files)
+
+        # Set the input files for each variable if they are not set
+        use_sfc_wind = self.detect_parameters.use_sfc_wind
+        for filename in self._input_files:
+            with Dataset(filename, "r") as nc_file:
+                variables = nc_file.variables
+
+                if self._u_in_file is None and (
+                    (use_sfc_wind and "u_ref" in variables)
+                    or (not use_sfc_wind and "u850" in variables)
+                ):
+                    self._u_in_file = os.path.abspath(filename)
+
+                if self._v_in_file is None and (
+                    (use_sfc_wind and "v_ref" in variables)
+                    or (not use_sfc_wind and "v850" in variables)
+                ):
+                    self._v_in_file = os.path.abspath(filename)
+
+                if self._vort_in_file is None and "vort850" in variables:
+                    self._vort_in_file = os.path.abspath(filename)
+
+                if self._tm_in_file is None and "tm" in variables:
+                    self._tm_in_file = os.path.abspath(filename)
+
+                if self._slp_in_file is None and "slp" in variables:
+                    self._slp_in_file = os.path.abspath(filename)
+
+    def _in_file(self, var: str) -> str:
+        """Get the filepath for one of the input files."""
+        file_attr = f"_{var}_in_file"
+
+        if getattr(self, file_attr) is None:
+            msg = (
+                f"`{file_attr}` not set. Ensure that the input files include all "
+                "required variables and that `set_input_files` has been called."
+            )
+            raise RuntimeError(msg)
+
+        return getattr(self, file_attr)
 
     def _write_driver_namelist(self) -> str:
         """
@@ -327,7 +396,6 @@ class TSTORMSTracker(TCTracker):
         namelist_path = os.path.join(output_dir, "nml_driver")
 
         # Format the namelist content
-        input_dir = self.tstorms_parameters.input_dir
         detect_params = self.detect_parameters
         namelist_content = textwrap.dedent(f"""
          &nml_tstorms
@@ -341,11 +409,11 @@ class TSTORMSTracker(TCTracker):
           do_thickness= {".true." if detect_params.do_thickness else ".false."}
          &end
          &input
-           fn_u    = '{os.path.join(input_dir, detect_params.u_in_file)}'
-           fn_v    = '{os.path.join(input_dir, detect_params.v_in_file)}'
-           fn_vort = '{os.path.join(input_dir, detect_params.vort_in_file)}'
-           fn_tm   = '{os.path.join(input_dir, detect_params.tm_in_file)}'
-           fn_slp  = '{os.path.join(input_dir, detect_params.slp_in_file)}'
+           fn_u    = '{self._in_file("u")}'
+           fn_v    = '{self._in_file("v")}'
+           fn_vort = '{self._in_file("vort")}'
+           fn_tm   = '{self._in_file("tm")}'
+           fn_slp  = '{self._in_file("slp")}'
            use_sfc_wnd = {".true." if detect_params.use_sfc_wind else ".false."}
          &end
         """)
@@ -667,7 +735,6 @@ class TSTORMSTracker(TCTracker):
         ValueError
             If a variable is not found in the input files.
         """
-        input_dir = self.tstorms_parameters.input_dir
         detect_params = self.detect_parameters
         var_outputs: list[dict] = [
             {
@@ -676,7 +743,7 @@ class TSTORMSTracker(TCTracker):
                     "Surface Wind Speed" if detect_params.use_sfc_wind else "Wind Speed"
                 ),
                 "tstorms_name": ("u_ref" if detect_params.use_sfc_wind else "u850"),
-                "filename": os.path.join(input_dir, detect_params.u_in_file),
+                "filename": self._in_file("u"),
                 "cellmethod": cf.CellMethod(
                     "area",
                     "maximum",
@@ -691,7 +758,7 @@ class TSTORMSTracker(TCTracker):
                 "std_name": "air_pressure_at_mean_sea_level",
                 "long_name": "Air Pressure at Mean Sea Level",
                 "tstorms_name": "slp",
-                "filename": os.path.join(input_dir, detect_params.slp_in_file),
+                "filename": self._in_file("slp"),
                 "cellmethod": cf.CellMethod(
                     "area",
                     "maximum",
@@ -706,7 +773,7 @@ class TSTORMSTracker(TCTracker):
                 "std_name": "atmosphere_upward_relative_vorticity",
                 "long_name": "Atmosphere Upward Relative Vorticity",
                 "tstorms_name": "vort850",
-                "filename": os.path.join(input_dir, detect_params.vort_in_file),
+                "filename": self._in_file("vort"),
                 "cellmethod": cf.CellMethod(
                     "area",
                     "maximum",
@@ -786,9 +853,7 @@ class TSTORMSTracker(TCTracker):
             If the 'calendar' attribute is missing for the coordinate variable.
             Defaults to 'julian'.
         """
-        input_u_file = os.path.join(
-            self.tstorms_parameters.input_dir, self.detect_parameters.u_in_file
-        )
+        input_u_file = self._in_file("u")
 
         with Dataset(input_u_file, "r") as nc_file:
             unlimited_dims = [

--- a/src/tctrack/utils/metadata.py
+++ b/src/tctrack/utils/metadata.py
@@ -89,7 +89,7 @@ def load_tracker_metadata(filename: str) -> tuple[type, list[TCTrackerParameters
 
     >>> tracker_cls, parameters = load_tracker_metadata("tracks.nc")
     >>> tracker = tracker_cls(*parameters)
-    >>> tracker.run_tracker("tracks_new.nc")
+    >>> tracker.run_tracker("inputs.nc", "tracks_new.nc")
     """
     _, tracker_name, parameter_dicts = _read_metadata(filename)
 

--- a/tests/integration/test_tracker_integration.py
+++ b/tests/integration/test_tracker_integration.py
@@ -66,7 +66,6 @@ class TestTETrackerIntegration:
         output_file = str(tmp_path / "tracks.nc")
 
         dn_params = te.TEDetectParameters(
-            in_data=[synthetic_data_file],
             search_by_min="psl",
             merge_dist=6.0,
             closed_contours=[
@@ -86,7 +85,7 @@ class TestTETrackerIntegration:
         )
 
         tracker = te.TETracker(dn_params, sn_params)
-        tracker.run_tracker(output_file)
+        tracker.run_tracker(synthetic_data_file, output_file)
 
         fields = cf.read(output_file)  # type: ignore[operator]
         assert len(fields) > 0, "No fields written to output file"

--- a/tests/unit/core/test_tracker.py
+++ b/tests/unit/core/test_tracker.py
@@ -6,6 +6,7 @@ import re
 import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Iterable
 
 import cf
 import numpy as np
@@ -112,7 +113,7 @@ class TestTCTracker:
     class ExampleTracker(TCTracker):
         """Concrete implementation of TCTracker for testing purposes."""
 
-        def __init__(self, example_trajectories):
+        def __init__(self, example_trajectories=None):
             self._example_trajectories = example_trajectories
             self.params = ExampleParameters(42, "test")
 
@@ -132,7 +133,11 @@ class TestTCTracker:
             """Implement a dummy of the read_trajectories abstractmethod."""
             return self._example_trajectories
 
-        def run_tracker(self, output_file: str) -> None:  # noqa:ARG002 unused arg
+        def run_tracker(
+            self,
+            input_files: str | Iterable[str],  # noqa:ARG002 unused arg
+            output_file: str,  # noqa:ARG002 unused arg
+        ) -> None:
             """Implement a dummy of the run_tracker abstractmethod."""
             return None
 
@@ -244,6 +249,49 @@ class TestTCTracker:
             ),
         }
         assert tracker.global_metadata == expected_metadata
+
+    def test_set_input_files_tuple(self, mocker):
+        """Test that `set_input_files` converts tuple inputs into a list."""
+        # Ignore test that file exists
+        mocker.patch("pathlib.Path.exists")
+
+        tracker = self.ExampleTracker()
+        tracker.set_input_files(("a", "b"))
+        assert isinstance(tracker._input_files, list)  # noqa:SLF001 - private member access
+        assert tracker._input_files == ["a", "b"]  # noqa:SLF001 - private member access
+
+    def test_set_input_files_string(self, mocker):
+        """Test that `set_input_files` converts a string argument into a list."""
+        # Ignore test that file exists
+        mocker.patch("pathlib.Path.exists")
+
+        tracker = self.ExampleTracker()
+        tracker.set_input_files("input.nc")
+        assert isinstance(tracker._input_files, list)  # noqa:SLF001 - private member access
+        assert tracker._input_files == ["input.nc"]  # noqa:SLF001 - private member access
+
+    @pytest.mark.parametrize("inputs", [True, ["string", 1]])
+    def test_set_input_files_invalid(self, inputs):
+        """Test that `set_input_files` raises error for invalid inputs."""
+        tracker = self.ExampleTracker()
+        with pytest.raises(TypeError, match="must be a str or an iterable of str"):
+            tracker.set_input_files(inputs)
+
+    def test_set_input_files_missing(self):
+        """Test that `set_input_files` fails if the input file doesn't exist."""
+        tracker = self.ExampleTracker()
+        with pytest.raises(FileNotFoundError, match="Input file does not exist"):
+            tracker.set_input_files("missing")
+
+    def test_set_input_files_exists(self, tmp_path: Path):
+        """Test that `set_input_files` succeeds if the file exists."""
+        input_file = tmp_path / "input.nc"
+        input_file.touch()
+
+        tracker = self.ExampleTracker()
+        tracker.set_input_files(str(input_file))
+        assert isinstance(tracker._input_files, list)  # noqa:SLF001 - private member access
+        assert tracker._input_files == [str(input_file)]  # noqa:SLF001 - private member access
 
     def make_netcdf_file(self, tmp_path: Path, delete_std_name: bool = False) -> Path:
         """Output a trajectories netcdf file with to_netcdf.

--- a/tests/unit/tempest_extremes/test_tempest_extremes.py
+++ b/tests/unit/tempest_extremes/test_tempest_extremes.py
@@ -31,7 +31,7 @@ class TestTETypes:
 
     def test_detect_parameters_defaults(self) -> None:
         """Check the default values for TEDetectParameters."""
-        params = TEDetectParameters(in_data=["input_file.nc"])
+        params = TEDetectParameters()
         # Check values of all defaults
         assert params.out_header is False
         assert params.output_dir == ""
@@ -147,17 +147,13 @@ class TestTETracker:
     # Test for TETracker initialization
     def test_te_tracker_initialization(self) -> None:
         """Test initialisation of TETracker with some non-default parameters."""
-        params = TEDetectParameters(
-            in_data=["input_file.nc"],
-            output_dir="outputs",
-        )
+        params = TEDetectParameters(output_dir="outputs")
         tracker = TETracker(detect_parameters=params)
         assert tracker.detect_parameters.output_dir == "outputs"
 
     def test_te_tracker_tempfiles(self) -> None:
         """Test the definition of temporary files when not manually defined."""
-        dn_params = TEDetectParameters(in_data=["input_file.nc"])
-        tracker = TETracker(dn_params)
+        tracker = TETracker()
         tempdir = tracker._tempdir.name  # noqa: SLF001 - private member access
         assert Path(tempdir).exists()
         assert tracker.detect_parameters.output_dir == tempdir
@@ -203,11 +199,9 @@ class TestTETracker:
             "units": "Pa",
         }
         file_name = netcdf_psl_file(properties)
-        dn_params = TEDetectParameters(
-            in_data=[file_name],
-            search_by_min="psl",
-        )
+        dn_params = TEDetectParameters(search_by_min="psl")
         tracker = TETracker(dn_params)
+        tracker.set_input_files(file_name)
 
         # Assert the metadata extracted correctly
         tracker.set_metadata()
@@ -221,11 +215,9 @@ class TestTETracker:
     def test_te_tracker_time_metadata_variable_not_found(self, netcdf_psl_file):
         """Test ValueError raised when the main search variable not found in inputs."""
         file_name = netcdf_psl_file({})
-        dn_params = TEDetectParameters(
-            in_data=[file_name],
-            search_by_min="not_psl",
-        )
+        dn_params = TEDetectParameters(search_by_min="not_psl")
         tracker = TETracker(dn_params)
+        tracker.set_input_files(file_name)
 
         with pytest.raises(
             ValueError, match=r"Variable 'not_psl' not found in input files."
@@ -241,11 +233,11 @@ class TestTETracker:
         }
         file_name = netcdf_psl_file(properties)
         dn_params = TEDetectParameters(
-            in_data=[file_name],
             search_by_min="psl",
             output_commands=[TEOutputCommand(var="psl", operator="min", dist=1)],
         )
         tracker = TETracker(dn_params)
+        tracker.set_input_files(file_name)
         tracker.set_metadata()
         metadata = tracker.variable_metadata
 
@@ -276,11 +268,11 @@ class TestTETracker:
         }
         file_name = netcdf_psl_file(properties)
         dn_params = TEDetectParameters(
-            in_data=[file_name],
             search_by_min="psl",
             output_commands=[TEOutputCommand(var="invalid", operator="min", dist=1)],
         )
         tracker = TETracker(dn_params)
+        tracker.set_input_files(file_name)
         with pytest.raises(
             ValueError,
             match=r"Variable 'invalid' not found in input files.",
@@ -291,11 +283,11 @@ class TestTETracker:
         """Check set_metadata for missing metadata."""
         file_name = netcdf_psl_file({})
         dn_params = TEDetectParameters(
-            in_data=[file_name],
             search_by_min="psl",
             output_commands=[TEOutputCommand(var="psl", operator="min", dist=1)],
         )
         tracker = TETracker(dn_params)
+        tracker.set_input_files(file_name)
         tracker.set_metadata()
         metadata = tracker.variable_metadata
         assert "psl" in metadata
@@ -313,11 +305,9 @@ class TestTETracker:
     def test_te_tracker_global_metadata(self, netcdf_psl_file) -> None:
         """Check set_metadata correctly sets _global_metadata."""
         file_name = netcdf_psl_file({})
-        dn_params = TEDetectParameters(
-            in_data=[file_name],
-            search_by_min="psl",
-        )
+        dn_params = TEDetectParameters(search_by_min="psl")
         tracker = TETracker(dn_params)
+        tracker.set_input_files(file_name)
         tracker.set_metadata()
 
         assert tracker.global_metadata is not None
@@ -546,8 +536,7 @@ class TestTETracker:
     ):
         """Test read_trajectories for different formats and multiple trajectories."""
         mock_file = request.getfixturevalue(mock_file_fixture)
-        dn_params = TEDetectParameters(in_data=["input_file.nc"])
-        tracker = TETracker(dn_params)
+        tracker = TETracker()
         tracker.stitch_parameters.output_dir = str(mock_file.parent)
         tracker.stitch_parameters.output_file = mock_file.name
         tracker.stitch_parameters.out_file_format = file_format
@@ -583,9 +572,7 @@ class TestTETracker:
             TEOutputCommand(var="v1", operator="min", dist=0.0),
             TEOutputCommand(var="v2", operator="min", dist=0.0),
         ]
-        dn_params = TEDetectParameters(
-            in_data=["input_file.nc"], output_commands=output_commands
-        )
+        dn_params = TEDetectParameters(output_commands=output_commands)
         tracker = TETracker(dn_params)
 
         # Read in the trajectories
@@ -612,12 +599,14 @@ class TestTETracker:
         self, file_format, mock_file_fixture, netcdf_psl_file, request, tmp_path: Path
     ):
         """Test the to_netcdf method by writing out and validating with cf.read."""
-        # Get the mock file and set up the TETracker
-        mock_file = request.getfixturevalue(mock_file_fixture)
-        file_name = netcdf_psl_file({})
-        dn_params = TEDetectParameters(in_data=[file_name], search_by_min="psl")
+        # Set up the TETracker
+        dn_params = TEDetectParameters(search_by_min="psl")
         sn_params = TEStitchParameters(in_fmt=["lon", "lat", "v1", "v2"])
         tracker = TETracker(dn_params, stitch_parameters=sn_params)
+        tracker.set_input_files(netcdf_psl_file({}))
+
+        # Set the tracker to use the mocked intermediate output file
+        mock_file = request.getfixturevalue(mock_file_fixture)
         tracker.stitch_parameters.output_dir = str(mock_file.parent)
         tracker.stitch_parameters.output_file = mock_file.name
         tracker.stitch_parameters.out_file_format = file_format
@@ -659,12 +648,11 @@ class TestTETracker:
         )
 
         # Set up psl file with metadata for time
-        file_name = netcdf_psl_file({})
-        dn_params = TEDetectParameters(in_data=[file_name], search_by_min="psl")
+        input_file_name = netcdf_psl_file({})
 
         # Use the mock_gfdl_file to simulate the output of StitchNodes
         sn_in_fmt = ["lon", "lat", "psl", "orog"]
-        dn_params = TEDetectParameters(in_data=[file_name], search_by_min="psl")
+        dn_params = TEDetectParameters(search_by_min="psl")
         sn_params = TEStitchParameters(
             output_dir=str(mock_gfdl_file.parent),
             output_file=mock_gfdl_file.name,
@@ -674,17 +662,17 @@ class TestTETracker:
 
         # Check run_tracker runs without error and produces an output file
         output_file = tmp_path / "trajectories.nc"
-        tracker.run_tracker(str(output_file))
+        tracker.run_tracker(input_file_name, str(output_file))
         assert output_file.exists()
 
     def test_run_tracker_failure(self, mocker) -> None:
         """Check run_tracker propagates RuntimeError from detect/stitch."""
         # Create tracker object
-        dn_params = TEDetectParameters(in_data=["input_file.nc"])
-        tracker = TETracker(dn_params)
+        tracker = TETracker()
 
         # Mock subprocess.run and define a function to mock fail for a specific command
         mocker.patch("pathlib.Path.mkdir")
+        mocker.patch("pathlib.Path.exists")
         mock_subprocess_run = mocker.patch("subprocess.run")
 
         def subprocess_failure(cmd, args, **_kwargs):
@@ -714,7 +702,7 @@ class TestTETracker:
         with pytest.raises(
             RuntimeError, match="DetectNodes failed with a non-zero exit code"
         ):
-            tracker.run_tracker("trajectories.nc")
+            tracker.run_tracker("input_file.nc", "trajectories.nc")
 
         # Check a RuntimeError is correctly raised for stitch
         mock_subprocess_run.side_effect = lambda args, **kwargs: subprocess_failure(
@@ -723,7 +711,7 @@ class TestTETracker:
         with pytest.raises(
             RuntimeError, match="StitchNodes failed with a non-zero exit code"
         ):
-            tracker.run_tracker("trajectories.nc")
+            tracker.run_tracker("input_file.nc", "trajectories.nc")
 
 
 class TestTETrackerDetect:
@@ -731,6 +719,8 @@ class TestTETrackerDetect:
 
     def test_te_tracker_detect_defaults(self, mocker) -> None:
         """Checks the correct detect call is made for defaults."""
+        mocker.patch("pathlib.Path.exists")
+
         # Mock the creation of the output directory
         mock_mkdir = mocker.patch("pathlib.Path.mkdir", autospec=True)
 
@@ -741,8 +731,8 @@ class TestTETrackerDetect:
         )
 
         # create a TETracker with default parameters and call detect method
-        dn_params = TEDetectParameters(in_data=["input_file.nc"])
-        tracker = TETracker(dn_params)
+        tracker = TETracker()
+        tracker.set_input_files("input_file.nc")
         result = tracker.detect()
         outdir = tracker._tempdir.name  # noqa: SLF001 - private member access
 
@@ -785,6 +775,8 @@ class TestTETrackerDetect:
 
     def test_te_tracker_detect_non_defaults(self, mocker) -> None:
         """Checks the correct detect call is made for non-default values."""
+        mocker.patch("pathlib.Path.exists")
+
         # Mock the creation of the output directory
         mock_mkdir = mocker.patch("pathlib.Path.mkdir", autospec=True)
 
@@ -796,7 +788,6 @@ class TestTETrackerDetect:
 
         # Create a TETracker with non-default parameters and call detect method
         params = TEDetectParameters(
-            in_data=["input_data.nc"],
             output_dir="custom_outputs",
             output_file="custom_nodes.txt",
             merge_dist=10.0,
@@ -808,6 +799,7 @@ class TestTETrackerDetect:
             max_lon=180.0,
         )
         tracker = TETracker(detect_parameters=params)
+        tracker.set_input_files("input_data.nc")
         result = tracker.detect()
 
         # Check the mkdir call made as expected
@@ -858,6 +850,7 @@ class TestTETrackerDetect:
         """
         # Mock subprocess.run to simulate successful execution
         mocker.patch("pathlib.Path.mkdir")
+        mocker.patch("pathlib.Path.exists")
         mock_subprocess_run = mocker.patch("subprocess.run")
         mock_subprocess_run.return_value = mocker.MagicMock(
             returncode=0, stdout="Mocked stdout output", stderr="Mocked stderr output"
@@ -865,7 +858,6 @@ class TestTETrackerDetect:
 
         # Create a TETracker with optional parameters and call detect method
         params = TEDetectParameters(
-            in_data=["input1.nc", "input2.nc"],
             out_header=True,
             output_dir="outputs",
             search_by_min="psl",
@@ -880,6 +872,7 @@ class TestTETrackerDetect:
             regional=True,
         )
         tracker = TETracker(detect_parameters=params)
+        tracker.set_input_files(["input1.nc", "input2.nc"])
         result = tracker.detect()
 
         # Check subprocess call made as expected and returned outputs are passed back up
@@ -930,12 +923,13 @@ class TestTETrackerDetect:
         """Check detect raises FileNotFoundError when executable is missing."""
         # Mock subprocess.run to simulate a FileNotFoundError
         mocker.patch("pathlib.Path.mkdir")
+        mocker.patch("pathlib.Path.exists")
         mock_subprocess_run = mocker.patch("subprocess.run")
         mock_subprocess_run.side_effect = FileNotFoundError("Executable not found")
 
         # Create a TETracker instance
-        params = TEDetectParameters(in_data=["input_data.nc"], output_file="output.txt")
-        tracker = TETracker(detect_parameters=params)
+        tracker = TETracker()
+        tracker.set_input_files("input_data.nc")
 
         # Assert that detect raises FileNotFoundError
         with pytest.raises(
@@ -948,14 +942,15 @@ class TestTETrackerDetect:
         """Check detect raises RuntimeError on subprocess failure."""
         # Mock subprocess.run to simulate a failure
         mocker.patch("pathlib.Path.mkdir")
+        mocker.patch("pathlib.Path.exists")
         mock_subprocess_run = mocker.patch("subprocess.run")
         mock_subprocess_run.side_effect = subprocess.CalledProcessError(
             returncode=1, cmd="DetectNodes", stderr="Error occurred"
         )
 
         # Create a TETracker instance
-        params = TEDetectParameters(in_data=["input_data.nc"], output_file="output.txt")
-        tracker = TETracker(detect_parameters=params)
+        tracker = TETracker()
+        tracker.set_input_files("input_data.nc")
 
         # Assert that detect raises RuntimeError
         with pytest.raises(
@@ -979,8 +974,7 @@ class TestTETrackerStitch:
         )
 
         # Create a TETracker instance with default stitch parameters
-        dn_params = TEDetectParameters(in_data=["input_data.nc"])
-        tracker = TETracker(dn_params)
+        tracker = TETracker()
         result = tracker.stitch()
         outdir = tracker._tempdir.name  # noqa: SLF001 - private member access
 
@@ -1033,7 +1027,6 @@ class TestTETrackerStitch:
         )
 
         # Create a TETracker instance with non-default stitch parameters
-        dn_params = TEDetectParameters(in_data=["input_data.nc"])
         sn_params = TEStitchParameters(
             output_dir="custom_outputs",
             output_file="custom_trajectories.txt",
@@ -1047,7 +1040,7 @@ class TestTETrackerStitch:
             out_file_format="csv",
             out_seconds=True,
         )
-        tracker = TETracker(dn_params, stitch_parameters=sn_params)
+        tracker = TETracker(stitch_parameters=sn_params)
         result = tracker.stitch()
 
         # Check the mkdir call made as expected
@@ -1124,13 +1117,12 @@ class TestTETrackerStitch:
         )
 
         # Create a TETracker instance with threshold filters
-        dn_params = TEDetectParameters(in_data=["input_data.nc"])
         sn_params = TEStitchParameters(
             output_dir="outputs",
             in_file="nodes.txt",
             threshold_filters=threshold_filters,
         )
-        tracker = TETracker(dn_params, stitch_parameters=sn_params)
+        tracker = TETracker(stitch_parameters=sn_params)
         result = tracker.stitch()
 
         # Check subprocess call made as expected and returned outputs are passed back up
@@ -1172,14 +1164,13 @@ class TestTETrackerStitch:
         "dn_params, sn_params, expected",
         [
             pytest.param(
-                TEDetectParameters(in_data=["infile.txt"]),
+                None,
                 None,
                 [None, None],
                 id="Check defaults",
             ),
             pytest.param(
                 TEDetectParameters(
-                    in_data=["infile.txt"],
                     output_dir="outputs",
                     output_file="file.txt",
                     output_commands=[
@@ -1193,7 +1184,6 @@ class TestTETrackerStitch:
             ),
             pytest.param(
                 TEDetectParameters(
-                    in_data=["infile.txt"],
                     output_dir="outputs",
                     output_commands=[
                         TEOutputCommand(var="v1", operator="min", dist=0.0),
@@ -1222,8 +1212,7 @@ class TestTETrackerStitch:
         mock_subprocess_run.side_effect = FileNotFoundError("Executable not found")
 
         # Create a TETracker instance
-        dn_params = TEDetectParameters(in_data=["input_data.nc"])
-        tracker = TETracker(dn_params)
+        tracker = TETracker()
 
         # Assert that stitch raises FileNotFoundError
         with pytest.raises(
@@ -1242,8 +1231,7 @@ class TestTETrackerStitch:
         )
 
         # Create a TETracker instance
-        dn_params = TEDetectParameters(in_data=["input_data.nc"])
-        tracker = TETracker(dn_params)
+        tracker = TETracker()
 
         # Assert that stitch raises RuntimeError
         with pytest.raises(

--- a/tests/unit/track/test_track.py
+++ b/tests/unit/track/test_track.py
@@ -459,3 +459,24 @@ class TestTrackTracker:
                 {"TRACKParameters": asdict(tracker.parameters)}
             ),
         }
+
+    def test_run_tracker(self, mocker, tmp_path):
+        """Check run_tracker runs successfully and produces."""
+        # Create the input and intermediate output files
+        input_file = self._create_nc_input_file(tmp_path)
+        self._create_nc_output_file(tmp_path)
+
+        # Mock subprocess.run to simulate successful execution
+        mock_subprocess_run = mocker.patch("subprocess.run")
+        mock_subprocess_run.side_effect = mocker.MagicMock(
+            returncode=0, stdout="Success"
+        )
+
+        # Create the tracker
+        params = {"base_dir": str(tmp_path), "input_file": input_file}
+        tracker = self._setup_tracker(mocker, mock_input_file=False, params_dict=params)
+
+        # Run the tracker and check if the output file is created
+        output_file = tmp_path / "output.nc"
+        tracker.run_tracker(input_file, str(output_file))
+        assert output_file.exists()

--- a/tests/unit/track/test_track.py
+++ b/tests/unit/track/test_track.py
@@ -9,7 +9,6 @@ import importlib.metadata
 import json
 from dataclasses import asdict
 from pathlib import Path
-from unittest import mock
 
 import cf
 import cftime
@@ -25,9 +24,8 @@ class TestTrackParameters:
 
     def test_parameters_defaults(self):
         """Check TRACKParameters default values."""
-        params = TRACKParameters(base_dir="dir", input_file="input")
+        params = TRACKParameters(base_dir="dir")
         assert params.base_dir == "dir"
-        assert params.input_file == "input"
         assert params.filter_distance is None
         assert params.wind_var_names == ("ua", "va")
         assert params.pressure_level == 85000
@@ -63,24 +61,21 @@ class TestTrackTracker:
             returncode=0, stdout="Mocked stdout output", stderr="Mocked stderr output"
         )
 
+        # Optionally mock the reading of the input file
+        if mock_input_file:
+            self.mock_lat_lon = mocker.patch(
+                "tctrack.track.track.lat_lon_sizes", return_value=(self.ny, self.nx)
+            )
+            self.mock_path_exists = mocker.patch("pathlib.Path.exists")
+
         # Create the parameters
         if params_dict is None:
             params_dict = {}
         params_dict.setdefault("base_dir", "dir")
-        params_dict.setdefault("input_file", "input")
         params = TRACKParameters(**params_dict)
 
-        # Create the tracker, optionally mocking the reading of the input file
-        if mock_input_file is False:
-            tracker = TRACKTracker(params)
-        else:
-            with (
-                mock.patch(
-                    "tctrack.track.track.lat_lon_sizes", return_value=(self.ny, self.nx)
-                ),
-                mock.patch("pathlib.Path.exists"),
-            ):
-                tracker = TRACKTracker(params)
+        # Create the tracker
+        tracker = TRACKTracker(params)
 
         if clear_copy:
             self.mock_copy.reset_mock()
@@ -88,11 +83,7 @@ class TestTrackTracker:
 
     def test_initialisation(self, mocker):
         """Check TRACKTracker initialises correctly."""
-        tracker = self._setup_tracker(mocker, clear_copy=False)
-
-        # Check attributes
-        assert tracker._nx == self.nx  # noqa: SLF001 - private member access
-        assert tracker._ny == self.ny  # noqa: SLF001 - private member access
+        _ = self._setup_tracker(mocker, clear_copy=False)
 
         # Check calls to shutil.copy are as expected
         copy_calls = [
@@ -101,14 +92,33 @@ class TestTrackTracker:
         ]
         self.mock_copy.assert_has_calls(copy_calls)
 
-    def test_initialisation_failure(self, mocker):
-        """Check TRACKTracker initialisation fails as expected."""
+    def test_set_input_files(self, mocker):
+        """Check set_input_files correctly sets attributes."""
+        tracker = self._setup_tracker(mocker)
+
+        tracker.set_input_files("input")
+
+        assert tracker._input_files == ["input"]  # noqa: SLF001 - private member access
+        assert tracker._nx == self.nx  # noqa: SLF001 - private member access
+        assert tracker._ny == self.ny  # noqa: SLF001 - private member access
+
+    def test_set_input_files_missing(self, mocker):
+        """Check set_input_files fails for missing files."""
+        tracker = self._setup_tracker(mocker, mock_input_file=False)
+
         with pytest.raises(FileNotFoundError, match="Input file does not exist"):
-            self._setup_tracker(mocker, mock_input_file=False)
+            tracker.set_input_files("missing")
+
+    def test_set_input_files_multiple(self, mocker):
+        """Check set_input_files fails for multiple input files."""
+        tracker = self._setup_tracker(mocker)
+
+        with pytest.raises(ValueError, match="TRACK only accepts one input"):
+            tracker.set_input_files(["file1", "file2"])
 
     def test_export_inputs(self, mocker):
         """Check the command line inputs are correctly exported."""
-        tracker = self._setup_tracker(mocker)
+        tracker = self._setup_tracker(mocker, mock_input_file=False)
         tracker.parameters.export_inputs = True
 
         command_name = "export"
@@ -175,12 +185,13 @@ class TestTrackTracker:
     def test_calculate_vorticity(self, mocker):
         """Check calculate_vorticity calls TRACK with the expected inputs."""
         tracker = self._setup_tracker(mocker)
+        input_file = "input"
+        tracker.set_input_files(input_file)
 
         # Run the method
         tracker.calculate_vorticity()
 
         # Expected inputs
-        input_file = tracker.parameters.input_file
         input_params = [
             *["n", "0", "4", "n", "1", "y", "ua", "n", "85000", "n", "g"],
             *["n", "1", str(self.nx), "1", str(self.ny), "y", "12", "0", "2", "y"],
@@ -205,6 +216,8 @@ class TestTrackTracker:
     def test_spectral_filtering(self, mocker):
         """Check spectral_filtering calls TRACK with the expected inputs."""
         tracker = self._setup_tracker(mocker)
+        tracker._nx = self.nx  # noqa: SLF001 - private member access
+        tracker._ny = self.ny  # noqa: SLF001 - private member access
 
         # Run the method
         tracker.spectral_filtering()
@@ -358,8 +371,9 @@ class TestTrackTracker:
         input_file = self._create_nc_input_file(tmp_path)
 
         # Set up the tracker pointing to the created files
-        params = {"base_dir": str(tmp_path), "input_file": input_file}
+        params = {"base_dir": str(tmp_path)}
         tracker = self._setup_tracker(mocker, mock_input_file=False, params_dict=params)
+        tracker.set_input_files(input_file)
 
         # Get the trajectories
         trajectories = tracker.read_trajectories()
@@ -401,8 +415,9 @@ class TestTrackTracker:
     def test_variable_metadata(self, mocker, tmp_path: Path):
         """Test variable_metadata is defined correctly by set_metadata."""
         input_file = self._create_nc_input_file(tmp_path)
-        params = {"base_dir": str(tmp_path), "input_file": input_file}
+        params = {"base_dir": str(tmp_path)}
         tracker = self._setup_tracker(mocker, mock_input_file=False, params_dict=params)
+        tracker.set_input_files(input_file)
 
         tracker.set_metadata()
         metadata = tracker.variable_metadata
@@ -430,8 +445,9 @@ class TestTrackTracker:
     def test_time_metadata(self, mocker, tmp_path: Path):
         """Test time_metadata is defined correctly by set_metadata."""
         input_file = self._create_nc_input_file(tmp_path)
-        params = {"base_dir": str(tmp_path), "input_file": input_file}
+        params = {"base_dir": str(tmp_path)}
         tracker = self._setup_tracker(mocker, mock_input_file=False, params_dict=params)
+        tracker.set_input_files(input_file)
 
         tracker.set_metadata()
 
@@ -446,8 +462,9 @@ class TestTrackTracker:
     def test_global_metadata(self, mocker, tmp_path: Path):
         """Test global_metadata is defined correctly by set_metadata."""
         input_file = self._create_nc_input_file(tmp_path)
-        params = {"base_dir": str(tmp_path), "input_file": input_file}
+        params = {"base_dir": str(tmp_path)}
         tracker = self._setup_tracker(mocker, mock_input_file=False, params_dict=params)
+        tracker.set_input_files(input_file)
 
         tracker.set_metadata()
 
@@ -473,7 +490,7 @@ class TestTrackTracker:
         )
 
         # Create the tracker
-        params = {"base_dir": str(tmp_path), "input_file": input_file}
+        params = {"base_dir": str(tmp_path)}
         tracker = self._setup_tracker(mocker, mock_input_file=False, params_dict=params)
 
         # Run the tracker and check if the output file is created

--- a/tests/unit/tstorms/test_tstorms.py
+++ b/tests/unit/tstorms/test_tstorms.py
@@ -18,6 +18,7 @@ import cf
 import numpy as np
 import pytest
 from cftime import datetime
+from netCDF4 import Dataset
 
 from tctrack.tstorms import (
     TSTORMSBaseParameters,
@@ -195,6 +196,68 @@ class TestTSTORMSTypes:
 
 class TestTSTORMSTracker:
     """Tests for the TSTORMS Tracker class."""
+
+    def test_initialisation_no_inputs(self, tmp_path):
+        """Test tracker initialisation without inputs in detect parameters."""
+        base_params = TSTORMSBaseParameters(
+            tstorms_dir=str(tmp_path / "tstorms"),
+            output_dir=str(tmp_path / "tstorms/output"),
+        )
+        tracker = TSTORMSTracker(base_params)
+
+        assert tracker._u_in_file is None  # noqa: SLF001 - private member access
+        assert tracker._v_in_file is None  # noqa: SLF001 - private member access
+        assert tracker._vort_in_file is None  # noqa: SLF001 - private member access
+        assert tracker._tm_in_file is None  # noqa: SLF001 - private member access
+        assert tracker._slp_in_file is None  # noqa: SLF001 - private member access
+
+    def test_initialisation_inputs(self, tmp_path):
+        """Test tracker initialisation with inputs in detect parameters."""
+        input_dir = str(tmp_path / "tstorms/input")
+        base_params = TSTORMSBaseParameters(
+            tstorms_dir=str(tmp_path / "tstorms"),
+            output_dir=str(tmp_path / "tstorms/output"),
+            input_dir=input_dir,
+        )
+        detect_params = TSTORMSDetectParameters(
+            u_in_file="u.nc",
+            v_in_file="v.nc",
+            vort_in_file="vort.nc",
+            tm_in_file="tm.nc",
+            slp_in_file="slp.nc",
+        )
+        tracker = TSTORMSTracker(base_params, detect_params)
+
+        assert tracker._u_in_file == os.path.join(input_dir, "u.nc")  # noqa: SLF001 - private member access
+        assert tracker._v_in_file == os.path.join(input_dir, "v.nc")  # noqa: SLF001 - private member access
+        assert tracker._vort_in_file == os.path.join(input_dir, "vort.nc")  # noqa: SLF001 - private member access
+        assert tracker._tm_in_file == os.path.join(input_dir, "tm.nc")  # noqa: SLF001 - private member access
+        assert tracker._slp_in_file == os.path.join(input_dir, "slp.nc")  # noqa: SLF001 - private member access
+
+    def test_set_input_files(self, tmp_path):
+        """Test the variable input files are automatically set by set_input_files."""
+        base_params = TSTORMSBaseParameters(
+            tstorms_dir=str(tmp_path / "tstorms"),
+            output_dir=str(tmp_path / "tstorms/output"),
+        )
+        tracker = TSTORMSTracker(base_params)
+
+        # Create the netcdf files with the appropriate variable names
+        inputs = []
+        for var_name in ["u_ref", "v_ref", "vort850", "tm", "slp"]:
+            filename = str(tmp_path / f"{var_name}.nc")
+            with Dataset(filename, "w") as nc_file:
+                nc_file.createVariable(var_name, "f")
+            inputs.append(filename)
+
+        tracker.set_input_files(inputs)
+
+        # Check the attributes have been set correctly
+        assert tracker._u_in_file == str(tmp_path / "u_ref.nc")  # noqa: SLF001 - private member access
+        assert tracker._v_in_file == str(tmp_path / "v_ref.nc")  # noqa: SLF001 - private member access
+        assert tracker._vort_in_file == str(tmp_path / "vort850.nc")  # noqa: SLF001 - private member access
+        assert tracker._tm_in_file == str(tmp_path / "tm.nc")  # noqa: SLF001 - private member access
+        assert tracker._slp_in_file == str(tmp_path / "slp.nc")  # noqa: SLF001 - private member access
 
     def test_write_driver_namelist(self, tstorms_tracker):
         """Test the generation of the driver namelist."""
@@ -815,7 +878,7 @@ class TestTSTORMSTracker:
             f.write("Mock cyclones content")
 
         output_file = os.path.join(output_dir, "trajectories.nc")
-        tracker.run_tracker(output_file)
+        tracker.run_tracker([], output_file)
         assert os.path.exists(output_file)
 
     def test_run_tracker_failure(self, mocker, tstorms_tracker, mock_trav_file) -> None:
@@ -861,7 +924,7 @@ class TestTSTORMSTracker:
         with pytest.raises(
             RuntimeError, match="Detect failed with a non-zero exit code"
         ):
-            tracker.run_tracker("trajectories.nc")
+            tracker.run_tracker([], "trajectories.nc")
 
         # Check a RuntimeError is correctly raised for stitch (trajectory_analysis)
         mock_subprocess_run.side_effect = lambda args, **kwargs: subprocess_failure(
@@ -870,7 +933,7 @@ class TestTSTORMSTracker:
         with pytest.raises(
             RuntimeError, match="Stitch failed with a non-zero exit code"
         ):
-            tracker.run_tracker("trajectories.nc")
+            tracker.run_tracker([], "trajectories.nc")
 
 
 class TestTSTORMSTrackerDetect:

--- a/tests/unit/utils/test_metadata.py
+++ b/tests/unit/utils/test_metadata.py
@@ -41,7 +41,7 @@ METADATA_CASES = [
     ),
     pytest.param(
         TRACKTracker,
-        [TRACKParameters(base_dir="track_dir", input_file="input.nc")],
+        [TRACKParameters(base_dir="track_dir")],
         id="track",
     ),
 ]

--- a/tests/unit/utils/test_metadata.py
+++ b/tests/unit/utils/test_metadata.py
@@ -21,7 +21,7 @@ from tctrack.utils.metadata import _read_metadata
 METADATA_CASES = [
     pytest.param(
         TETracker,
-        [TEDetectParameters(in_data=["input.nc"]), TEStitchParameters()],
+        [TEDetectParameters(), TEStitchParameters()],
         id="tempest_extremes",
     ),
     pytest.param(

--- a/tutorial/run_tempest_extremes.py
+++ b/tutorial/run_tempest_extremes.py
@@ -32,7 +32,6 @@ threshold_filters = [
 ]
 
 dn_params = te.TEDetectParameters(
-    in_data=input_files,
     search_by_min="psl",
     time_filter="6hr",
     merge_dist=6.0,
@@ -53,4 +52,4 @@ sn_params = te.TEStitchParameters(
 
 te_tracker = te.TETracker(dn_params, sn_params)
 
-te_tracker.run_tracker("tracks_tempest_extremes.nc")
+te_tracker.run_tracker(input_files, "tracks_tempest_extremes.nc")

--- a/tutorial/run_tstorms.py
+++ b/tutorial/run_tstorms.py
@@ -7,15 +7,9 @@ from tctrack import tstorms
 tstorms_params = tstorms.TSTORMSBaseParameters(
     tstorms_dir=f"{os.getcwd()}/TSTORMS",
     output_dir="tstorms_outputs",
-    input_dir=f"{os.getcwd()}/data_processed",
 )
 
 detect_params = tstorms.TSTORMSDetectParameters(
-    u_in_file="u_ref_day_ASO50.nc",
-    v_in_file="v_ref_day_ASO50.nc",
-    vort_in_file="vort850_day_ASO50.nc",
-    tm_in_file="tm_day_ASO50.nc",
-    slp_in_file="slp_day_ASO50.nc",
     vort_crit=3.5e-5,
     tm_crit=0.0,
     thick_crit=50.0,
@@ -38,8 +32,16 @@ stitch_params = tstorms.TSTORMSStitchParameters(
     lat_bound_s=-70.0,
 )
 
+input_files = [
+    "data_processed/u_ref_day_ASO50.nc",
+    "data_processed/v_ref_day_ASO50.nc",
+    "data_processed/vort850_day_ASO50.nc",
+    "data_processed/tm_day_ASO50.nc",
+    "data_processed/slp_day_ASO50.nc",
+]
+
 tstorms_tracker = tstorms.TSTORMSTracker(tstorms_params, detect_params, stitch_params)
-tstorms_tracker.run_tracker("tracks_tstorms.nc")
+tstorms_tracker.run_tracker(input_files, "tracks_tstorms.nc")
 
 # tstorms_tracker.stitch(verbosity=2)
 # tstorms_tracker.to_netcdf("tracks_tstorms.nc")


### PR DESCRIPTION
This standardises how the input files are defined across the trackers. Rather than defining them in the parameter classes they are now passed to `run_tracker`, e.g. `tracker.run_tracker("inputs.nc", "tracks.nc")`. It allows either a single file as a string or a list of files.

This replaces `in_data` in TE, `input_file` in TRACK ,  and the various `in_file` parameters in TSTORMS.

If instead running step-by-step it requires manually calling `tracker.set_input_files("inputs.nc")` which stores the inputs in a `_input_files` attribute and checks the files exists. TRACK and TSTORMS override this to store additional input file specific attributes.

Closes #210 

This also fixes a bug in how the time metadata is stored in TRACK.