### PR TITLE
Fix type errors in testing

### DIFF
--- a/src/tctrack/preprocessing.py
+++ b/src/tctrack/preprocessing.py
@@ -76,13 +76,13 @@ def _write_output(
 
 
 @overload
-def _write_output(
+def _write_output(  # type: ignore[overload-cannot-match]
     result: list[cf.Field], output_file: str | None, squeeze: Literal[True] = True
 ) -> cf.Field | list[cf.Field]: ...
 
 
 @overload
-def _write_output(
+def _write_output(  # type: ignore[overload-cannot-match]
     result: list[cf.Field], output_file: str | None, squeeze: Literal[False]
 ) -> list[cf.Field]: ...
 

--- a/tests/integration/test_tracker_integration.py
+++ b/tests/integration/test_tracker_integration.py
@@ -1,5 +1,7 @@
 """Integration tests for the TempestExtremes tracker pipeline."""
 
+from pathlib import Path
+
 import cf
 import cftime
 import numpy as np
@@ -10,7 +12,7 @@ import tctrack.tempest_extremes as te
 
 
 @pytest.fixture
-def synthetic_data_file(tmp_path):
+def synthetic_data_file(tmp_path: Path):
     """NetCDF file with a Gaussian psl minimum planted at (15°N, 45°E) over 5 days.
 
     The depression has amplitude -1500 Pa and sigma=3°, so at 5.5° from the
@@ -52,7 +54,9 @@ def synthetic_data_file(tmp_path):
 class TestTETrackerIntegration:
     """Integration tests for the full TETracker pipeline."""
 
-    def test_run_tracker_produces_valid_tracks(self, synthetic_data_file, tmp_path):
+    def test_run_tracker_produces_valid_tracks(
+        self, synthetic_data_file, tmp_path: Path
+    ):
         """TETracker detects the synthetic pressure minimum and writes a track file.
 
         Verifies the full chain: DetectNodes → StitchNodes → CF-NetCDF output.

--- a/tests/integration/test_tracker_integration.py
+++ b/tests/integration/test_tracker_integration.py
@@ -84,7 +84,7 @@ class TestTETrackerIntegration:
         tracker = te.TETracker(dn_params, sn_params)
         tracker.run_tracker(output_file)
 
-        fields = cf.read(output_file)
+        fields = cf.read(output_file)  # type: ignore[operator]
         assert len(fields) > 0, "No fields written to output file"
 
         field = fields[0]

--- a/tests/unit/core/test_netcdf.py
+++ b/tests/unit/core/test_netcdf.py
@@ -1,5 +1,7 @@
 """Unit tests for netcdf utility functions in the TCTrack utils Python package."""
 
+from pathlib import Path
+
 import pytest
 from netCDF4 import Dataset
 
@@ -30,7 +32,9 @@ class TestNetCDF:
             pytest.param({"lon": 10}, {}, (20, 10), KeyError, id="missing dimension"),
         ],
     )
-    def test_lat_lon_sizes_valid(self, tmp_path, dims, lat_lon_names, expected, raises):
+    def test_lat_lon_sizes_valid(
+        self, tmp_path: Path, dims, lat_lon_names, expected, raises
+    ):
         """Test lat_lon_sizes returns the expected values / the expected error."""
         ncfile = tmp_path / "test.nc"
         self.create_netcdf_file(ncfile, dims)

--- a/tests/unit/core/test_tracker.py
+++ b/tests/unit/core/test_tracker.py
@@ -344,7 +344,7 @@ class TestTCTracker:
         netcdf_file = self.make_netcdf_file(tmp_path)
 
         # Read back with cf.read
-        fields = cf.read(str(netcdf_file))
+        fields = cf.read(str(netcdf_file))  # type: ignore[operator]
 
         # Validate the structure and content - one variable field
         assert len(fields) == 1
@@ -375,7 +375,7 @@ class TestTCTracker:
         netcdf_file = self.make_netcdf_file(tmp_path, delete_std_name)
 
         # Read back with cf.read
-        field = cf.read(str(netcdf_file))[0]
+        field = cf.read(str(netcdf_file))[0]  # type: ignore[operator]
 
         # Check the fields (variables) - just one in this test
         variable = "test_var"
@@ -430,7 +430,7 @@ class TestTCTracker:
         netcdf_file = self.make_netcdf_file(tmp_path)
 
         # Read back with cf.read
-        fields = cf.read(str(netcdf_file))
+        fields = cf.read(str(netcdf_file))  # type: ignore[operator]
 
         # Check the fields (variables) - just one in this test
         variable = fields.select_by_identity("test_standard_name")[0]
@@ -450,7 +450,7 @@ class TestTCTracker:
         netcdf_file = self.make_netcdf_file(tmp_path)
 
         # Read back with cf.read
-        field = cf.read(str(netcdf_file))[0]
+        field = cf.read(str(netcdf_file))[0]  # type: ignore[operator]
 
         # Check the global metadata is written correctly
         global_metadata = field.nc_global_attributes(values=True)

--- a/tests/unit/core/test_tracker.py
+++ b/tests/unit/core/test_tracker.py
@@ -2,7 +2,6 @@
 
 import importlib.metadata
 import json
-import pathlib
 import re
 import tempfile
 from dataclasses import asdict, dataclass
@@ -246,11 +245,7 @@ class TestTCTracker:
         }
         assert tracker.global_metadata == expected_metadata
 
-    def make_netcdf_file(
-        self,
-        tmp_path: pathlib.Path,
-        delete_std_name: bool = False,
-    ) -> pathlib.Path:
+    def make_netcdf_file(self, tmp_path: Path, delete_std_name: bool = False) -> Path:
         """Output a trajectories netcdf file with to_netcdf.
 
         We will take some predefined Trajectories (matching the variable_metadata and
@@ -320,12 +315,12 @@ class TestTCTracker:
 
         return output_file
 
-    def test_to_netcdf(self, tmp_path):
+    def test_to_netcdf(self, tmp_path: Path):
         """Test to_netcdf writes trajectories to a file in the netcdf_file fixture."""
         netcdf_file = self.make_netcdf_file(tmp_path)
         assert netcdf_file.exists()
 
-    def test_to_netcdf_no_trajectories(self, tmp_path):
+    def test_to_netcdf_no_trajectories(self, tmp_path: Path):
         """Test to_netcdf raises warning and exits gracefully when no trajectories."""
         # Instantiate the dummy tracker with empty trajectories
         tracker = self.ExampleTracker([])
@@ -339,7 +334,7 @@ class TestTCTracker:
             tracker.to_netcdf(str(netcdf_file))
         assert not netcdf_file.exists()
 
-    def test_to_netcdf_data(self, tmp_path):
+    def test_to_netcdf_data(self, tmp_path: Path):
         """Check to_netcdf writes trajectories with the correct data and dimensions."""
         netcdf_file = self.make_netcdf_file(tmp_path)
 
@@ -370,7 +365,7 @@ class TestTCTracker:
         assert np.allclose(var_data[1, :], [15.0, 20.0, 15.0])
 
     @pytest.mark.parametrize("delete_std_name", [False, True])
-    def test_to_netcdf_variable_metadata(self, tmp_path, delete_std_name):
+    def test_to_netcdf_variable_metadata(self, tmp_path: Path, delete_std_name):
         """Check to_netcdf writes trajectories with the correct variable metadata."""
         netcdf_file = self.make_netcdf_file(tmp_path, delete_std_name)
 
@@ -425,7 +420,7 @@ class TestTCTracker:
                     f"Metadata mismatch for {variable}: {key}"
                 )
 
-    def test_to_netcdf_track_flag(self, tmp_path):
+    def test_to_netcdf_track_flag(self, tmp_path: Path):
         """Check to_netcdf correctly flags tracks at start and end of file."""
         netcdf_file = self.make_netcdf_file(tmp_path)
 
@@ -445,7 +440,7 @@ class TestTCTracker:
         assert np.array_equal(start_flag.value().array, [True, False, False])
         assert np.array_equal(end_flag.value().array, [False, False, True])
 
-    def test_to_netcdf_global_metadata(self, tmp_path):
+    def test_to_netcdf_global_metadata(self, tmp_path: Path):
         """Check to_netcdf writes trajectories with the correct global metadata."""
         netcdf_file = self.make_netcdf_file(tmp_path)
 

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -48,7 +48,7 @@ def write_fields(fields: cf.Field | list[cf.Field], path: Path) -> str:
 class TestPreprocessing:
     """Tests for preprocessing functions."""
 
-    def test_read_files_combines_fields(self, tmp_path):
+    def test_read_files_combines_fields(self, tmp_path: Path):
         """Test read_files accepts files with multiple fields."""
         input_file = write_fields(
             [make_field("mslp"), make_field("u")],
@@ -59,7 +59,7 @@ class TestPreprocessing:
 
         assert [field.nc_get_variable() for field in fields] == ["mslp", "u"]
 
-    def test_read_files_combines_time(self, tmp_path):
+    def test_read_files_combines_time(self, tmp_path: Path):
         """Test read_files accepts and combines fields split temporally over files."""
         input_files = [
             write_fields(make_field("mslp", "2000-01-01"), tmp_path / "a.nc"),
@@ -71,7 +71,7 @@ class TestPreprocessing:
         assert len(fields) == 1
         assert fields[0].coordinate("T").size == 2
 
-    def test_read_files_wildcard(self, tmp_path):
+    def test_read_files_wildcard(self, tmp_path: Path):
         """Test read_files correctly expands wildcard filepaths."""
         write_fields(make_field("mslp"), tmp_path / "a.nc")
         write_fields(make_field("u"), tmp_path / "b.nc")
@@ -80,12 +80,12 @@ class TestPreprocessing:
 
         assert len(fields) == 2
 
-    def test_read_files_wildcard_no_matches(self, tmp_path):
+    def test_read_files_wildcard_no_matches(self, tmp_path: Path):
         """Test read_files fails for wildcard paths with no matches."""
         with pytest.raises(FileNotFoundError, match="No files matched input pattern"):
             read_files(str(tmp_path / "*.nc"))
 
-    def test_read_files_output_file(self, tmp_path):
+    def test_read_files_output_file(self, tmp_path: Path):
         """Test read_files writes the combined output when requested."""
         input_file = write_fields(make_field("mslp"), tmp_path / "input.nc")
         output_file = tmp_path / "output.nc"
@@ -96,7 +96,7 @@ class TestPreprocessing:
         assert output_file.exists()
         assert cf.read(str(output_file))[0].nc_get_variable() == "mslp"  # type: ignore[operator]
 
-    def test_select_time_range_bounds(self, tmp_path):
+    def test_select_time_range_bounds(self, tmp_path: Path):
         """Test select_time_range correctly selects data in time bounds."""
         input_files = [
             write_fields(make_field("mslp", "2000-01-01"), tmp_path / "a.nc"),
@@ -115,7 +115,7 @@ class TestPreprocessing:
         assert fields[0].coordinate("T").size == 1
         assert fields[1].coordinate("T").size == 1
 
-    def test_select_time_range_squeeze(self, tmp_path):
+    def test_select_time_range_squeeze(self, tmp_path: Path):
         """Test select_time_range squeezes size-1 list outputs."""
         input_files = [
             write_fields(make_field("mslp", "2000-01-01"), tmp_path / "a.nc"),
@@ -129,7 +129,7 @@ class TestPreprocessing:
         assert output.nc_get_variable() == "mslp"
         assert output.coordinate("T").size == 1
 
-    def test_separate_varibles(self, tmp_path):
+    def test_separate_varibles(self, tmp_path: Path):
         """Test separate_variables correctly splits variables across multiple files."""
         input_file = write_fields(
             [make_field("mslp"), make_field("u")],
@@ -146,7 +146,7 @@ class TestPreprocessing:
         assert read_files(output_files["mslp"])[0] == fields[0]
         assert read_files(output_files["u"])[0] == fields[1]
 
-    def test_separate_varibles_invalid(self, tmp_path):
+    def test_separate_varibles_invalid(self, tmp_path: Path):
         """Test separate_variables fails if an invalid variable name is given."""
         input_file = write_fields(make_field("mslp"), tmp_path / "input.nc")
 
@@ -159,7 +159,7 @@ class TestPreprocessing:
 
         assert _load_field(field) is field
 
-    def test_load_field_accepts_files(self, tmp_path):
+    def test_load_field_accepts_files(self, tmp_path: Path):
         """Test _load_field accepts a filename / list of files."""
         file_a = write_fields(make_field("mslp", "2000-01-01"), tmp_path / "a.nc")
         file_b = write_fields(make_field("mslp", "2000-01-02"), tmp_path / "b.nc")
@@ -169,7 +169,7 @@ class TestPreprocessing:
         assert field.nc_get_variable() == "mslp"
         assert field.coordinate("T").size == 2
 
-    def test_load_field_rejects_multifield_files(self, tmp_path):
+    def test_load_field_rejects_multifield_files(self, tmp_path: Path):
         """Test _load_field rejects files with multiple fields."""
         input_file = write_fields(
             [make_field("u"), make_field("v")],
@@ -179,7 +179,7 @@ class TestPreprocessing:
         with pytest.raises(ValueError, match=r"Use {.*} to select a field"):
             _load_field(input_file)
 
-    def test_load_field_accepts_field_select(self, tmp_path):
+    def test_load_field_accepts_field_select(self, tmp_path: Path):
         """Test _load_field selects a field when given a FieldSelect dictionary."""
         input_file = write_fields(
             [make_field("mslp"), make_field("u")],
@@ -190,7 +190,7 @@ class TestPreprocessing:
 
         assert field.nc_get_variable() == "u"
 
-    def test_load_field_rejects_missing_field_select(self, tmp_path):
+    def test_load_field_rejects_missing_field_select(self, tmp_path: Path):
         """Test _load_field fails when a selected variable is missing."""
         input_file = write_fields(make_field("mslp"), tmp_path / "input.nc")
 

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -94,7 +94,7 @@ class TestPreprocessing:
 
         assert len(fields) == 1
         assert output_file.exists()
-        assert cf.read(str(output_file))[0].nc_get_variable() == "mslp"
+        assert cf.read(str(output_file))[0].nc_get_variable() == "mslp"  # type: ignore[operator]
 
     def test_select_time_range_bounds(self, tmp_path):
         """Test select_time_range correctly selects data in time bounds."""

--- a/tests/unit/tempest_extremes/test_tempest_extremes.py
+++ b/tests/unit/tempest_extremes/test_tempest_extremes.py
@@ -628,7 +628,7 @@ class TestTETracker:
         tracker.to_netcdf(output_file_name)
 
         # Read the generated NetCDF file using cf-python
-        fields = cf.read(output_file_name)
+        fields = cf.read(output_file_name)  # type: ignore[operator]
 
         # Validate the structure and content of the NetCDF file
         assert len(fields) == 4  # Ensure 4 fields (lat, lon become coordinates)

--- a/tests/unit/tempest_extremes/test_tempest_extremes.py
+++ b/tests/unit/tempest_extremes/test_tempest_extremes.py
@@ -169,7 +169,7 @@ class TestTETracker:
         assert not Path(tempdir).exists()
 
     @pytest.fixture
-    def netcdf_psl_file(self, tmp_path):
+    def netcdf_psl_file(self, tmp_path: Path):
         """Create a netcdf file with metadata given by the 'properties' argument."""
 
         def _create_file(properties):
@@ -390,7 +390,7 @@ class TestTETracker:
         }
 
     @pytest.fixture
-    def mock_gfdl_file(self, tmp_path) -> Path:
+    def mock_gfdl_file(self, tmp_path: Path) -> Path:
         """Fixture to create a mock GFDL file with two trajectories."""
         file_path = tmp_path / "trajectories_out_gfdl.txt"
         mock_data = self._mock_trajectories_data()
@@ -410,7 +410,7 @@ class TestTETracker:
         return file_path
 
     @pytest.fixture
-    def mock_csv_file(self, tmp_path) -> Path:
+    def mock_csv_file(self, tmp_path: Path) -> Path:
         """Fixture to create a mock CSV file with two trajectories."""
         file_path = tmp_path / "trajectories_out_csv.txt"
         mock_data = self._mock_trajectories_data()
@@ -430,7 +430,7 @@ class TestTETracker:
         return file_path
 
     @pytest.fixture
-    def mock_csvnohead_file(self, tmp_path) -> Path:
+    def mock_csvnohead_file(self, tmp_path: Path) -> Path:
         """Fixture to create mock CSV file with two trajectories and without header."""
         file_path = tmp_path / "trajectories_out_csvnohead.txt"
         mock_data = self._mock_trajectories_data()
@@ -609,7 +609,7 @@ class TestTETracker:
         ],
     )
     def test_to_netcdf_with_cf_read(
-        self, file_format, mock_file_fixture, netcdf_psl_file, request, tmp_path
+        self, file_format, mock_file_fixture, netcdf_psl_file, request, tmp_path: Path
     ):
         """Test the to_netcdf method by writing out and validating with cf.read."""
         # Get the mock file and set up the TETracker
@@ -648,7 +648,7 @@ class TestTETracker:
         assert lat_coord.shape == lon_coord.shape == (trajectory_ids, observation_count)
 
     def test_run_tracker_success(
-        self, mocker, tmp_path, netcdf_psl_file, mock_gfdl_file
+        self, mocker, tmp_path: Path, netcdf_psl_file, mock_gfdl_file
     ) -> None:
         """Check run_tracker runs successfully."""
         # Mock subprocess.run to simulate successful execution
@@ -674,7 +674,7 @@ class TestTETracker:
 
         # Check run_tracker runs without error and produces an output file
         output_file = tmp_path / "trajectories.nc"
-        tracker.run_tracker(output_file)
+        tracker.run_tracker(str(output_file))
         assert output_file.exists()
 
     def test_run_tracker_failure(self, mocker) -> None:

--- a/tests/unit/track/test_track.py
+++ b/tests/unit/track/test_track.py
@@ -125,7 +125,7 @@ class TestTrackTracker:
         assert file_path.read_text() == expected_result
         file_path.unlink()  # cleanup
 
-    def test_export_inputs_no_directory(self, mocker, tmp_path):
+    def test_export_inputs_no_directory(self, mocker, tmp_path: Path):
         """Check a directory is created when it doesn't exist."""
         tracker = self._setup_tracker(mocker)
 
@@ -138,7 +138,7 @@ class TestTrackTracker:
         file_path = tmp_path / "a" / "b" / f"{command_name}.in"
         assert file_path.exists()
 
-    def test_read_inputs(self, mocker, tmp_path):
+    def test_read_inputs(self, mocker, tmp_path: Path):
         """Check reading of exported command line inputs is correct."""
         tracker = self._setup_tracker(mocker)
         tracker.parameters.read_inputs = True
@@ -298,7 +298,7 @@ class TestTrackTracker:
             cwd=None,
         )
 
-    def _create_nc_output_file(self, tmp_path):
+    def _create_nc_output_file(self, tmp_path: Path):
         """Create a minimal TRACK NetCDF output file with 2 tracks."""
         directory = tmp_path / "outdat"
         directory.mkdir()
@@ -330,7 +330,7 @@ class TestTrackTracker:
             lat[:] = [0, -1, -2, -3, -4]
             intensity[:] = [0, 10, 20, 30, 40]
 
-    def _create_nc_input_file(self, tmp_path):
+    def _create_nc_input_file(self, tmp_path: Path):
         """Create a minimal NetCDF input file with defined times."""
         file_path = tmp_path / "input.nc"
 
@@ -351,7 +351,7 @@ class TestTrackTracker:
 
         return str(file_path)
 
-    def test_read_trajectories(self, mocker, tmp_path):
+    def test_read_trajectories(self, mocker, tmp_path: Path):
         """Check read_trajectories correctly reads in the output netcdf file."""
         # Create the temporary input and output files
         self._create_nc_output_file(tmp_path)
@@ -398,7 +398,7 @@ class TestTrackTracker:
         ):
             tracker.read_trajectories()
 
-    def test_variable_metadata(self, mocker, tmp_path):
+    def test_variable_metadata(self, mocker, tmp_path: Path):
         """Test variable_metadata is defined correctly by set_metadata."""
         input_file = self._create_nc_input_file(tmp_path)
         params = {"base_dir": str(tmp_path), "input_file": input_file}
@@ -427,7 +427,7 @@ class TestTrackTracker:
         assert metadata["intensity"].constructs == expected_constructs
         assert metadata["intensity"].construct_kwargs == expected_construct_kwargs
 
-    def test_time_metadata(self, mocker, tmp_path):
+    def test_time_metadata(self, mocker, tmp_path: Path):
         """Test time_metadata is defined correctly by set_metadata."""
         input_file = self._create_nc_input_file(tmp_path)
         params = {"base_dir": str(tmp_path), "input_file": input_file}
@@ -443,7 +443,7 @@ class TestTrackTracker:
             "end_time": cftime.datetime(1950, 1, 3, 0, calendar="360_day"),
         }
 
-    def test_global_metadata(self, mocker, tmp_path):
+    def test_global_metadata(self, mocker, tmp_path: Path):
         """Test global_metadata is defined correctly by set_metadata."""
         input_file = self._create_nc_input_file(tmp_path)
         params = {"base_dir": str(tmp_path), "input_file": input_file}

--- a/tests/unit/tstorms/test_tstorms.py
+++ b/tests/unit/tstorms/test_tstorms.py
@@ -11,6 +11,7 @@ import os
 import re
 import subprocess
 from dataclasses import asdict
+from pathlib import Path
 from typing import Tuple
 
 import cf
@@ -39,7 +40,7 @@ def tstorms_filenames() -> dict[str, str]:
 
 
 @pytest.fixture
-def tstorms_tracker(tmp_path, tstorms_filenames) -> Tuple[TSTORMSTracker, str]:
+def tstorms_tracker(tmp_path: Path, tstorms_filenames) -> Tuple[TSTORMSTracker, str]:
     """Provide a TSTORMSTracker instance with basic values."""
     # Create a tempdir for tstorms_dir and tstorms_driver (assumed to exist)
     tstorms_dir = tmp_path / "tstorms"
@@ -90,7 +91,7 @@ def tstorms_tracker(tmp_path, tstorms_filenames) -> Tuple[TSTORMSTracker, str]:
     # mypy ignore cf.write raises spurious warning but used elsewhere fine.
     cf.write(u_field, netcdf_file)  # type: ignore
 
-    return TSTORMSTracker(tstorms_parameters, detect_params), tstorms_dir
+    return TSTORMSTracker(tstorms_parameters, detect_params), str(tstorms_dir)
 
 
 class TestTSTORMSTypes:
@@ -673,7 +674,7 @@ class TestTSTORMSTracker:
         }
 
     @pytest.fixture
-    def mock_trav_file(self, tmp_path):
+    def mock_trav_file(self, tmp_path: Path):
         """Fixture to create a mock TSTORMS 'trav' file with sample trajectory data."""
         file_path = tmp_path / "trav_filt"
         mock_data = self._mock_trajectories_data()

--- a/tests/unit/utils/test_metadata.py
+++ b/tests/unit/utils/test_metadata.py
@@ -2,6 +2,7 @@
 
 import json
 from dataclasses import asdict
+from pathlib import Path
 
 import pytest
 from netCDF4 import Dataset
@@ -78,7 +79,7 @@ class TestMetadata:
         return parameter_dict
 
     @pytest.mark.parametrize("tracker_cls,parameters", METADATA_CASES)
-    def test_read_metadata(self, tmp_path, tracker_cls, parameters):
+    def test_read_metadata(self, tmp_path: Path, tracker_cls, parameters):
         """Test _read_metadata returns the stored metadata unchanged."""
         ncfile = tmp_path / "metadata.nc"
         parameter_dict = self.create_file_and_dict(tracker_cls, parameters, ncfile)
@@ -90,7 +91,9 @@ class TestMetadata:
         assert loaded_parameter_dict == parameter_dict
 
     @pytest.mark.parametrize("tracker_cls,parameters", METADATA_CASES)
-    def test_read_tracker_metadata(self, tmp_path, capsys, tracker_cls, parameters):
+    def test_read_tracker_metadata(
+        self, tmp_path: Path, capsys, tracker_cls, parameters
+    ):
         """Test read_tracker_metadata prints the metadata in the expected format."""
         ncfile = tmp_path / "metadata.nc"
         parameter_dict = self.create_file_and_dict(tracker_cls, parameters, ncfile)
@@ -113,7 +116,7 @@ class TestMetadata:
         assert capsys.readouterr().out == expected_output
 
     @pytest.mark.parametrize("tracker_cls,parameters", METADATA_CASES)
-    def test_load_tracker_metadata(self, tmp_path, tracker_cls, parameters):
+    def test_load_tracker_metadata(self, tmp_path: Path, tracker_cls, parameters):
         """Test load_tracker_metadata reconstructs tracker and parameter objects."""
         ncfile = tmp_path / "metadata.nc"
         parameter_dict = self.create_file_and_dict(tracker_cls, parameters, ncfile)
@@ -130,7 +133,7 @@ class TestMetadata:
         # Check the tracker is the same
         assert tracker is tracker_cls
 
-    def test_load_tracker_metadata_missing_attrs(self, tmp_path):
+    def test_load_tracker_metadata_missing_attrs(self, tmp_path: Path):
         """Test load_tracker_metadata raises a clear error for missing metadata."""
         ncfile = tmp_path / "metadata.nc"
         self.create_metadata_file(ncfile, {"tctrack_version": "test-version"})


### PR DESCRIPTION
This fixes the bug in testing for cf-python==3.20.1 (closes #222). The issue was a `pathlib.Path` being passed instead of `str`. To ensure this is picked up by mypy in future I have added type hints for `tmp_path`.

Other fixes:
- Ignores mypy errors for `cf.read`
- Ignores mypy errors for overloads in `preprocessing.py`